### PR TITLE
documentation(EJ2-60275): Resolve the dead link on a documentation page

### DIFF
--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/feature-module.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/feature-module.md
@@ -45,4 +45,4 @@ Refer to the following table.
 ## See also
 
 * [Toolbar items](./toolbar)
-* [Toolbar customization](./how-to/toolbar_customization)
+* [Toolbar customization](./how-to/toolbar-customization)

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/feature-module.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/feature-module.md
@@ -9,7 +9,7 @@ documentation: ug
 ---
 
 
-# Feature modules
+# Feature modules in ASP.NET Core PDF Viewer control
 
 The PDF Viewer features are segregated into individual feature-wise modules to enable selectively referencing in the application. The required modules should be injected to extend its functionality. The following are the selective modules of PDF Viewer that can be included as required:
 

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/toolbar.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/toolbar.md
@@ -88,5 +88,5 @@ The PDF Viewer has an option to show or hide these grouped items in the default 
 
 ## See also
 
-* [Toolbar customization](./how-to/toolbar_customization)
+* [Toolbar customization](./how-to/toolbar-customization)
 * [Feature Modules](./feature-module)

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/toolbar.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/toolbar.md
@@ -9,7 +9,7 @@ documentation: ug
 ---
 
 
-# Built-in toolbar
+# Built-in toolbar in ASP.NET Core PDF Viewer control
 
 The PDF Viewer comes with a powerful built-in toolbar to execute important actions such as page navigation, text search,view mode,download,print,bookmark, and thumbnails.
 


### PR DESCRIPTION
Resolve the dead link by providing the proper link.