### PR TITLE
documentation(EJ2-71583): Included "formatBlock" type executeCommand …

### DIFF
--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/exec-command.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/exec-command.md
@@ -27,6 +27,7 @@ The execCommand will perform the following commands.
 | fontColor | Apply the specified font color for the selected text. |`rteObj.executeCommand('fontColor', 'yellow');`|
 | fontName | Apply the specified font name for the selected text. |`rteObj.executeCommand('fontName', 'Arial');`|
 | fontSize | Apply the specified font size for the selected text. |`rteObj.executeCommand('fontSize', '10pt');`|
+| formatBlock | Apply the specified format styles for the selected text. |`rteObj.executeCommand('formatBlock', 'H1');`|
 | backColor | Apply the specified background color the selected text. | `rteObj.executeCommand('backColor', 'red');`|
 | justifyCenter | Align the content with center margin. | `rteObj.executeCommand('justifyCenter');`|
 | justifyFull | Align the content with justify margin. |`rteObj.executeCommand('justifyFull');`|

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/exec-command.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/exec-command.md
@@ -26,6 +26,7 @@ In Rich Text Editor, execCommand used to perform commands for the modification o
 | fontColor | Apply the specified font color for the selected text. |`rteObj.executeCommand('fontColor', 'yellow');`|
 | fontName | Apply the specified font name for the selected text. |`rteObj.executeCommand('fontName', 'Arial');`|
 | fontSize | Apply the specified font size for the selected text. |`rteObj.executeCommand('fontSize', '10pt');`|
+| formatBlock | Apply the specified format styles for the selected text. |`rteObj.executeCommand('formatBlock', 'H1');`|
 | backColor | Apply the specified background color the selected text. | `rteObj.executeCommand('backColor', 'red');`|
 | justifyCenter | Align the content with center margin. | `rteObj.executeCommand('justifyCenter');`|
 | justifyFull | Align the content with justify margin. |`rteObj.executeCommand('justifyFull');`|


### PR DESCRIPTION
documentation(EJ2-71583): Included "formatBlock" type executeCommand which is missing in Core Mvc UG Documentation