### PR TITLE
Documentation(SC-43825): Added code snippets for converting .NET Core Web App from 2.2 code to 3.0 for Timezone topic in scheduler.

### DIFF
--- a/ej2-asp-core-mvc/schedule/EJ2_ASP.NETCORE/timezone.md
+++ b/ej2-asp-core-mvc/schedule/EJ2_ASP.NETCORE/timezone.md
@@ -52,17 +52,36 @@ The following code example displays an appointment from 9.00 AM to 10.00 AM when
 
 When a timezone is set to Scheduler through `timezone` property, the appointments will be displayed exactly based on the Scheduler timezone regardless of its client timezone. In core application, client timezone will be added by default. In order to render the appointments in the timezone which has been set to the scheduler, add the following code snippet in your `Startup.cs` file like below.
 
-```sh
-public void ConfigureServices(IServiceCollection services) 
-        { 
-            services.AddDbContext<ScheduleDataContext>(options => options.UseSqlServer(Configuration.GetConnectionString("ScheduleDataConnection"))); 
-            services.AddControllersWithViews(option => option.EnableEndpointRouting = false).AddNewtonsoftJson(); 
-            services.AddControllersWithViews() 
-                .AddNewtonsoftJson(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver()) 
-                .AddNewtonsoftJson(opt => opt.SerializerSettings.DateFormatHandling = Newtonsoft.Json.DateFormatHandling.MicrosoftDateFormat) 
-                .AddNewtonsoftJson(opt => opt.SerializerSettings.DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Local); 
-        }
-```
+{% tabs %}
+{% highlight c# tabtitle=".NET 2.2"%}
+
+public void ConfigureServices(IServiceCollection services) {
+    services.AddDbContext<ScheduleDataContext>(options =>
+        options.UseSqlServer(Configuration.GetConnectionString("ScheduleDataConnection"))
+    );
+    services.AddMvc()
+        .AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver())
+        .AddJsonOptions(options => options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore)
+        .AddJsonOptions(opt => opt.SerializerSettings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat)
+        .AddJsonOptions(opt => opt.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc);
+}
+
+{% endhighlight %}
+
+{% highlight c# tabtitle=".NET 3.0" %}
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddDbContext<ScheduleDataContext>(options => options.UseSqlServer(Configuration.GetConnectionString("ScheduleDataConnection")));
+    services.AddControllersWithViews(option => option.EnableEndpointRouting = false).AddNewtonsoftJson();
+    services.AddControllersWithViews()
+        .AddNewtonsoftJson(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver())
+        .AddNewtonsoftJson(opt => opt.SerializerSettings.DateFormatHandling = Newtonsoft.Json.DateFormatHandling.MicrosoftDateFormat)
+        .AddNewtonsoftJson(opt => opt.SerializerSettings.DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Local);
+}
+
+{% endhighlight %}
+{% endtabs %}
 
 In the following code example, appointments will be displayed based on Eastern Time (UTC -05:00).
 

--- a/ej2-asp-core-mvc/schedule/EJ2_ASP.NETCORE/timezone.md
+++ b/ej2-asp-core-mvc/schedule/EJ2_ASP.NETCORE/timezone.md
@@ -53,16 +53,15 @@ The following code example displays an appointment from 9.00 AM to 10.00 AM when
 When a timezone is set to Scheduler through `timezone` property, the appointments will be displayed exactly based on the Scheduler timezone regardless of its client timezone. In core application, client timezone will be added by default. In order to render the appointments in the timezone which has been set to the scheduler, add the following code snippet in your `Startup.cs` file like below.
 
 ```sh
-public void ConfigureServices(IServiceCollection services) {
-    services.AddDbContext<ScheduleDataContext>(options =>
-        options.UseSqlServer(Configuration.GetConnectionString("ScheduleDataConnection"))
-    );
-    services.AddMvc()
-        .AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver())
-        .AddJsonOptions(options => options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore)
-        .AddJsonOptions(opt => opt.SerializerSettings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat)
-        .AddJsonOptions(opt => opt.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc);
-}
+public void ConfigureServices(IServiceCollection services) 
+        { 
+            services.AddDbContext<ScheduleDataContext>(options => options.UseSqlServer(Configuration.GetConnectionString("ScheduleDataConnection"))); 
+            services.AddControllersWithViews(option => option.EnableEndpointRouting = false).AddNewtonsoftJson(); 
+            services.AddControllersWithViews() 
+                .AddNewtonsoftJson(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver()) 
+                .AddNewtonsoftJson(opt => opt.SerializerSettings.DateFormatHandling = Newtonsoft.Json.DateFormatHandling.MicrosoftDateFormat) 
+                .AddNewtonsoftJson(opt => opt.SerializerSettings.DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Local); 
+        }
 ```
 
 In the following code example, appointments will be displayed based on Eastern Time (UTC -05:00).


### PR DESCRIPTION
**Description:**
Updated code snippets for NET Core Web App 3.0 for Timezone topic in scheduler

**Areas affected and ensured:**
All possible cases

**Test cases:**
NA

**Test bed sample location:**
NA

**Additional checklist**
Did you run the automation against your fix? NA
Is there any API name change? No
Is there any existing behavior change of other features due to this code change? No
Does your new code introduce new warnings or binding errors? No
Does your code pass all FxCop and StyleCop rules? NA
Did you record this case in the unit test or UI test? No