### PR TITLE
documentation(ES-837798-Core-and-mvc-docs): mapping the api links and fix navigate link issues

### DIFF
--- a/ej2-asp-core-mvc/accordion/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/accordion/EJ2_ASP.MVC/getting-started.md
@@ -43,7 +43,7 @@ Add **Syncfusion.EJ2** namespace reference in `Web.config` under `Views` folder.
 
 ## Add style sheet
 
-Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways (CDN, NPM package, and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
+Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways ([CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
 
 {% tabs %}
 {% highlight c# tabtitle="~/_Layout.cshtml" %}

--- a/ej2-asp-core-mvc/appbar/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/appbar/EJ2_ASP.MVC/getting-started.md
@@ -42,7 +42,7 @@ Add **Syncfusion.EJ2** namespace reference in `Web.config` under `Views` folder.
 
 ## Add style sheet
 
-Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways (CDN, NPM package, and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
+Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways ([CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
 
 {% tabs %}
 {% highlight c# tabtitle="~/_Layout.cshtml" %}

--- a/ej2-asp-core-mvc/carousel/EJ2_ASP.MVC/populating-items.md
+++ b/ej2-asp-core-mvc/carousel/EJ2_ASP.MVC/populating-items.md
@@ -78,7 +78,7 @@ Using the `prev` or `next` public method of the Carousel component, you can swit
 
 ## Partial visible slides
 
-The Carousel component supports to show one complete slide and a partial view of adjacent (previous and next) slides at the same time. You can enable or disable the partial slides using the [`partialVisible`](../api/carousel/#partialVisible) property.
+The Carousel component supports to show one complete slide and a partial view of adjacent (previous and next) slides at the same time. You can enable or disable the partial slides using the [`partialVisible`](https://help.syncfusion.com/cr/aspnetmvc-js2/syncfusion.ej2.navigations.carousel.html#Syncfusion_EJ2_Navigations_Carousel_PartialVisible) property.
 {% tabs %}
 {% highlight razor tabtitle="CSHTML" %}
 {% include code-snippet/carousel/populating-items/partial-visible/razor %}

--- a/ej2-asp-core-mvc/carousel/EJ2_ASP.NETCORE/populating-items.md
+++ b/ej2-asp-core-mvc/carousel/EJ2_ASP.NETCORE/populating-items.md
@@ -73,7 +73,7 @@ Using the `prev` or `next` public method of the Carousel component, you can swit
 
 ## Partial visible slides
 
-The Carousel component supports to show one complete slide and a partial view of adjacent (previous and next) slides at the same time. You can enable or disable the partial slides using the [`partialVisible`](../api/carousel/#partialVisible) property.
+The Carousel component supports to show one complete slide and a partial view of adjacent (previous and next) slides at the same time. You can enable or disable the partial slides using the [`partialVisible`](https://help.syncfusion.com/cr/aspnetcore-js2/syncfusion.ej2.navigations.carousel.html#Syncfusion_EJ2_Navigations_Carousel_PartialVisible) property.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}

--- a/ej2-asp-core-mvc/schedule/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/schedule/EJ2_ASP.MVC/getting-started.md
@@ -43,7 +43,7 @@ Add **Syncfusion.EJ2** namespace reference in `Web.config` under `Views` folder.
 
 ## Add style sheet
 
-Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways (CDN, NPM package, and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
+Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways ([CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
 
 {% tabs %}
 {% highlight c# tabtitle="~/_Layout.cshtml" %}

--- a/ej2-asp-core-mvc/tab/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/tab/EJ2_ASP.MVC/getting-started.md
@@ -43,7 +43,7 @@ Add **Syncfusion.EJ2** namespace reference in `Web.config` under `Views` folder.
 
 ## Add style sheet
 
-Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways (CDN, NPM package, and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
+Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways ([CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
 
 {% tabs %}
 {% highlight c# tabtitle="~/_Layout.cshtml" %}

--- a/ej2-asp-core-mvc/tab/how-to/create-wizard-using-tab.md
+++ b/ej2-asp-core-mvc/tab/how-to/create-wizard-using-tab.md
@@ -11,7 +11,13 @@ documentation: ug
 
 # Create wizard using Tab
 
-Tab items can be disabled initial control rendering by passing the boolean value to [`disabled`](https://help.syncfusion.com/cr/cref_files/aspnetcore-js2/aspnetcore/Syncfusion.EJ2~Syncfusion.EJ2.Navigations.TabTabItem~Disabled.html) property of [`TabItem`](https://help.syncfusion.com/cr/cref_files/aspnetcore-js2/aspnetcore/Syncfusion.EJ2~Syncfusion.EJ2.Navigations.TabTabItem.html) class.
+{% if page.publishingplatform == "aspnet-core" %}
+
+Tab items can be disabled initial control rendering by passing the boolean value to [`disabled`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Navigations.TabTabItem.html#Syncfusion_EJ2_Navigations_TabTabItem_Disabled) property of [`TabItem`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Navigations.TabTabItem.html) class.
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+Tab items can be disabled initial control rendering by passing the boolean value to [`disabled`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.Navigations.TabTabItem.html#Syncfusion_EJ2_Navigations_TabTabItem_Disabled) property of [`TabItem`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.Navigations.TabTabItem.html) class.
 
 In the below Wizard sample, each Tab is integrated with required components to complete the reservation. Each field is provided with validation for all mandatory option to proceed to next tabs. Using Tab item's template property the components are added into content.
 

--- a/ej2-asp-core-mvc/tab/how-to/prevent-content-swipe-selection.md
+++ b/ej2-asp-core-mvc/tab/how-to/prevent-content-swipe-selection.md
@@ -11,7 +11,13 @@ documentation: ug
 
 # Prevent content swipe selection
 
+{% if page.publishingplatform == "aspnet-core" %}
+
 We can prevent the tab selection on touch swipe action by using the Tab [selecting](https://help.syncfusion.com/cr/cref_files/aspnetcore-js2/aspnetcore/Syncfusion.EJ2~Syncfusion.EJ2.Navigations.Tab~Selecting.html) &nbsp;event. Refer the below sample with preventing swipe selection.
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+We can prevent the tab selection on touch swipe action by using the Tab [selecting](https://help.syncfusion.com/cr/cref_files/aspnetmvc-js2/aspnetmvc/Syncfusion.EJ2~Syncfusion.EJ2.Navigations.Tab~Selecting.html) &nbsp;event. Refer the below sample with preventing swipe selection.
 
 {% if page.publishingplatform == "aspnet-core" %}
 

--- a/ej2-asp-core-mvc/toolbar/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/toolbar/EJ2_ASP.MVC/getting-started.md
@@ -43,7 +43,7 @@ Add **Syncfusion.EJ2** namespace reference in `Web.config` under `Views` folder.
 
 ## Add style sheet
 
-Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways (CDN, NPM package, and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
+Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentation/appearance/theme) to learn different ways ([CDN](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#cdn-reference), [NPM package](https://ej2.syncfusion.com/aspnetmvc/documentation/common/adding-script-references#node-package-manager-npm), and [CRG](https://ej2.syncfusion.com/aspnetmvc/documentation/common/custom-resource-generator)) to refer styles in ASP.NET MVC application, and to have the expected appearance for Syncfusion ASP.NET MVC controls. Here, the theme is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
 
 {% tabs %}
 {% highlight c# tabtitle="~/_Layout.cshtml" %}


### PR DESCRIPTION
Description:
Fix the link navigate issue and mapping api links in core and mvc  documentation

Areas affected and ensured:
All possible cases

Test cases:
NA

Test bed sample location:
NA

Additional checklist
Did you run the automation against your fix? NA
Is there any API name change? No
Is there any existing behavior change of other features due to this code change? No
Does your new code introduce new warnings or binding errors? No
Does your code pass all FxCop and StyleCop rules? NA
Did you record this case in the unit test or UI test? No