### PR TITLE
documentation(821682): Added missing localization & missing formatBlock in ExecuteCommand & Resolved the table format broken issue in the Rich Text Editor component documentation - Hotfix MVC/Core

### DIFF
--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/exec-command.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/exec-command.md
@@ -27,6 +27,7 @@ The execCommand will perform the following commands.
 | fontColor | Apply the specified font color for the selected text. |`rteObj.executeCommand('fontColor', 'yellow');`|
 | fontName | Apply the specified font name for the selected text. |`rteObj.executeCommand('fontName', 'Arial');`|
 | fontSize | Apply the specified font size for the selected text. |`rteObj.executeCommand('fontSize', '10pt');`|
+| formatBlock | Apply the specified format styles for the selected text. |`rteObj.executeCommand('formatBlock', 'H1');`|
 | backColor | Apply the specified background color the selected text. | `rteObj.executeCommand('backColor', 'red');`|
 | justifyCenter | Align the content with center margin. | `rteObj.executeCommand('justifyCenter');`|
 | justifyFull | Align the content with justify margin. |`rteObj.executeCommand('justifyFull');`|

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/globalization.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/globalization.md
@@ -157,7 +157,25 @@ The Rich Text Editor provides an option to localize its strings; it is used to a
             "fontNameImpact": "Impact",
             "fontNameTahoma": "Tahoma",
             "fontNameTimesNewRoman": "Times New Roman",
-            "fontNameVerdana": "Verdana"
+            "fontNameVerdana": "Verdana",
+            "numberFormatListNumber": 'Number',
+            "numberFormatListLowerAlpha": 'LowerAlpha',
+            "numberFormatListUpperAlpha": 'UpperAlpha',
+            "numberFormatListLowerRoman": 'LowerRoman',
+            "numberFormatListUpperRoman": 'UpperRoman',
+            "numberFormatListLowerGreek": 'LowerGreek',
+            "bulletFormatListDisc": 'Disc',
+            "bulletFormatListCircle": 'Circle',
+            "bulletFormatListSquare": 'Square',
+            "numberFormatListNone": 'None',
+            "bulletFormatListNone":'None',
+            "formatPainter": 'Format Painter',
+            "emojiPicker": 'Emoji Picker',
+            "embeddedCode": 'Embedded Code',
+            "pasteEmbeddedCodeHere": 'Paste Embedded Code here',
+            "emojiPickerTypeToFind": 'Type to find',
+            "emojiPickerNoResultFound": 'No results found',
+            "emojiPickerTrySomethingElse": 'Try something else',
         }
     }
 }

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/exec-command.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/exec-command.md
@@ -26,6 +26,7 @@ In Rich Text Editor, execCommand used to perform commands for the modification o
 | fontColor | Apply the specified font color for the selected text. |`rteObj.executeCommand('fontColor', 'yellow');`|
 | fontName | Apply the specified font name for the selected text. |`rteObj.executeCommand('fontName', 'Arial');`|
 | fontSize | Apply the specified font size for the selected text. |`rteObj.executeCommand('fontSize', '10pt');`|
+| formatBlock | Apply the specified format styles for the selected text. |`rteObj.executeCommand('formatBlock', 'H1');`|
 | backColor | Apply the specified background color the selected text. | `rteObj.executeCommand('backColor', 'red');`|
 | justifyCenter | Align the content with center margin. | `rteObj.executeCommand('justifyCenter');`|
 | justifyFull | Align the content with justify margin. |`rteObj.executeCommand('justifyFull');`|

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/globalization.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/globalization.md
@@ -157,7 +157,25 @@ The Rich Text Editor provides an option to localize its strings; it is used to a
             "fontNameImpact": "Impact",
             "fontNameTahoma": "Tahoma",
             "fontNameTimesNewRoman": "Times New Roman",
-            "fontNameVerdana": "Verdana"
+            "fontNameVerdana": "Verdana",
+            "numberFormatListNumber": 'Number',
+            "numberFormatListLowerAlpha": 'LowerAlpha',
+            "numberFormatListUpperAlpha": 'UpperAlpha',
+            "numberFormatListLowerRoman": 'LowerRoman',
+            "numberFormatListUpperRoman": 'UpperRoman',
+            "numberFormatListLowerGreek": 'LowerGreek',
+            "bulletFormatListDisc": 'Disc',
+            "bulletFormatListCircle": 'Circle',
+            "bulletFormatListSquare": 'Square',
+            "numberFormatListNone": 'None',
+            "bulletFormatListNone":'None',
+            "formatPainter": 'Format Painter',
+            "emojiPicker": 'Emoji Picker',
+            "embeddedCode": 'Embedded Code',
+            "pasteEmbeddedCodeHere": 'Paste Embedded Code here',
+            "emojiPickerTypeToFind": 'Type to find',
+            "emojiPickerNoResultFound": 'No results found',
+            "emojiPickerTrySomethingElse": 'Try something else',
         }
     }
 }


### PR DESCRIPTION
documentation(821682): Added missing localization & missing formatBlock in ExecuteCommand & Resolved the table format broken issue in the Rich Text Editor component documentation - Hotfix MVC/Core