### PR TITLE
Task 855214: To add the Colorpicker documentation, if the noColor property is set to true, we need to ensure that the modeswitcher property is set to false.

### DIFF
--- a/ej2-asp-core-mvc/color-picker/how-to/handle-no-color-support.md
+++ b/ej2-asp-core-mvc/color-picker/how-to/handle-no-color-support.md
@@ -38,7 +38,7 @@ In the following sample, the first tile of the color palette represents the no c
 {% endtabs %}
 {% endif %}
 
-
+>if the noColor property is set to true, ensure that the modeswitcher property is set to false.
 
 ## Custom no color
 

--- a/ej2-asp-core-mvc/color-picker/how-to/handle-no-color-support.md
+++ b/ej2-asp-core-mvc/color-picker/how-to/handle-no-color-support.md
@@ -38,7 +38,7 @@ In the following sample, the first tile of the color palette represents the no c
 {% endtabs %}
 {% endif %}
 
->if the noColor property is set to true, ensure that the modeswitcher property is set to false.
+>If the [noColor](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Inputs.ColorPicker.html#Syncfusion_EJ2_Inputs_ColorPicker_NoColor) property is enabled, make sure to disable the [modeswitcher](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Inputs.ColorPicker.html#Syncfusion_EJ2_Inputs_ColorPicker_ModeSwitcher) property.
 
 ## Custom no color
 


### PR DESCRIPTION
### Bug description

To add the Colorpicker documentation, if the noColor property is set to true, we need to ensure that the modeswitcher property is set to

### Root cause

NA

#### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.
- [x] Guidelines/documents are not followed
- [ ] Common guidelines / Core team guideline
- [ ] Specification document
- [ ] Requirement document

### Action taken:

Added in color picker documentation to ensure mode switcher property is false when no color property is set to true

### Related areas:

UG documentation

### Is it a breaking issue?

no

### Solution description

Added in color picker documentation to ensure mode switcher property is false when no color property is set to true

### Areas affected and ensured

Color picker ug documentation
