### PR TITLE
bug(857645):Need to add localization text for 'Total files' and 'Size'

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/uploader/localization/razor
+++ b/ej2-asp-core-mvc/code-snippet/uploader/localization/razor
@@ -20,8 +20,8 @@
                 "remove": "Retirer",
                 "cancel": "Annuler",
                 "delete": "Supprimer le fichier",
-                "totalFiles": 'Total des fichiers',
-                "size": 'taille'
+                "totalFiles": "Total des fichiers",
+                "size": "taille"
             }
         }
     })

--- a/ej2-asp-core-mvc/code-snippet/uploader/localization/razor
+++ b/ej2-asp-core-mvc/code-snippet/uploader/localization/razor
@@ -21,7 +21,7 @@
                 "cancel": "Annuler",
                 "delete": "Supprimer le fichier",
                 "totalFiles": 'Total des fichiers',
-                "size": 'taille',
+                "size": 'taille'
             }
         }
     })

--- a/ej2-asp-core-mvc/code-snippet/uploader/localization/razor
+++ b/ej2-asp-core-mvc/code-snippet/uploader/localization/razor
@@ -19,7 +19,9 @@
                 "readyToUploadMessage": "Prêt à télécharger",
                 "remove": "Retirer",
                 "cancel": "Annuler",
-                "delete": "Supprimer le fichier"
+                "delete": "Supprimer le fichier",
+                "totalFiles": 'Total des fichiers',
+                "size": 'taille',
             }
         }
     })

--- a/ej2-asp-core-mvc/uploader/localization.md
+++ b/ej2-asp-core-mvc/uploader/localization.md
@@ -35,6 +35,8 @@ The following are the list of keys and its values used in the uploader control:
 | remove | To customize tooltip text for remove icon. |
 | cancel | To customize tooltip text for cancel icon. |
 | delete | To customize tooltip text for delete icon. |
+| totalFiles | To customize tooltip text for total files. |
+| size | To customize tooltip text for size. |
 
 {% if page.publishingplatform == "aspnet-core" %}
 


### PR DESCRIPTION
### Bug description
Need to add localization text for 'Total files' and 'Size'
### Root cause
We have not added the for L10 for `Total files` and `Size` details to our documentaion.
### Solution description
To resolve this issue, to add the L10 for  `Total files` and `Size` details to our documentaion.
### Areas tested against this fix
- Ensure the changes affects others functionalities.

### Reason for not identifying earlier
 * [x] Guidelines not followed.

 * [ ] Guidelines not given.  

 * [ ] If any other reason, provide the details here. 
     
#### Areas tested against this fix
Provide details about the areas or combinations that have been tested against these code changes.
* [x]  Tested against feature matrix.


### Is it a breaking issue?
* [ ]  Yes
* [x]  NO 

Need to Ensure properly on Future implementation.
Already covered this bunit and got failed now.

 Feature matrix document updated
* [ ]  Yes
* [ ]  NO
* [x]  NA
 
Automation details - Mark `Is Automated` field as (Yes, Manual, Not Applicable) in corresponding JIRA task once the bug is automated. 
* [x] BUnit
 
If the same issue is reproduced in ej2, what will you do?
* [ ]  Resolved. Provide MR link.
* [ ]  No
* [x]  NA
 
 Is this common issue need to be addressed in the same component or on other components in our platform? 
* [ ]  Yes
* [x]  NO
  
### Output screenshots
- None

### EJ2 Checklist

Is there any new API or existing API name change?
* [ ]  Yes
* [x]  NO
  
Is there any existing behavior change due to this code change?
* [ ]  Yes
* [x]  NO


Do the code changes cause any memory leak and performance issue? (Test only if you suspect that your code may cause problem)
* [ ]  Yes
* [x]  NO

## Reviewer Checklist
* [x]  All provided information are reviewed and ensured.