### PR TITLE
847030: To validate and resolve the liquid exception error in RTE documentation sample.

### DIFF
--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/table.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/table.md
@@ -41,9 +41,6 @@ Tables can also be inserted through the `Insert Table` option in the pop-up wher
 {% elsif page.publishingplatform == "aspnet-mvc" %}
 
 {% tabs %}
-<!-- {% highlight razor tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/table/razor %}
-{% endhighlight %} -->
 {% highlight c# tabtitle="Controller.cs" %}
 {% include code-snippet/rich-text-editor/table/controller.cs %}
 {% endhighlight %}
@@ -152,9 +149,6 @@ The following image explains the table split action.
 {% elsif page.publishingplatform == "aspnet-mvc" %}
 
 {% tabs %}
-<!-- {% highlight razor tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/table-cell/razor %}
-{% endhighlight %} -->
 {% highlight c# tabtitle="Controller.cs" %}
 {% include code-snippet/rich-text-editor/table-cell/controller.cs %}
 {% endhighlight %}


### PR DESCRIPTION
### Bug description
To validate and resolve the liquid exception error in RTE documentation sample.

### Root Cause / Analysis

I have checked the reported issue, and the issue occurred because the path is not properly referred in the table.md file

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?
No

### Solution Description

I have removed the commend text in the table.md file.

### Areas affected and ensured

No

### E2E report details against this fix

No

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner