### PR TITLE
Update tagHelper example as current one's performance is terrible

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/multiselect/how-to/selected/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/multiselect/how-to/selected/tagHelper
@@ -9,15 +9,10 @@
     function onBegin(e) {
         this.fields = {
             text: 'Name', value: 'Code', itemCreated: function (e) {
-                var count = 0;
-                if (count === 0) {
-                    for (let i = 0; i < e.dataSource.length; i++) {
-                        if (e.curData.isSelected == true)
-                            itemSearch(e.curData.Code); //pass the corresponding value
-                    }
-                }
+                if (e.curData.isSelected == true)
+                    itemSearch(e.curData.Code); //pass the corresponding value
             }
-        }
+        }        
     }
     function itemSearch(e) {
         if (selected.indexOf(e) == -1)


### PR DESCRIPTION
The default example uses useless variables (count, which is set but never used) and also loops x times over the whole collection of items and potentially sets multiple event listeners instead of 1).

Instead, we should apply the following logic:
1. On begin, simply set the event handler once for the "itemCreated" event and in this handler: Check if the value should be pre-selected or not and add it to the "selected" array if it's the case.