### PR TITLE
878859: Need to correct the sample in Open And Save UG section of Spreadsheet.

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/spreadsheet/open-header/razor
+++ b/ej2-asp-core-mvc/code-snippet/spreadsheet/open-header/razor
@@ -6,7 +6,8 @@
 
 function beforeOpen(args) {
     args.requestData["headers"] = {
-      Authorization: "YOUR TEXT"
+      ...args.requestData,
+      headers: { Authorization: "YOUR TEXT" }
     };
 
   }

--- a/ej2-asp-core-mvc/code-snippet/spreadsheet/open-header/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/spreadsheet/open-header/tagHelper
@@ -5,7 +5,8 @@
 <script>
   function beforeOpen(args) {
       args.requestData["headers"] = {
-        Authorization: "YOUR TEXT"
+        ...args.requestData,
+        headers: { Authorization: "YOUR TEXT" }
       };
 
     } 

--- a/ej2-asp-core-mvc/code-snippet/spreadsheet/save-header/razor
+++ b/ej2-asp-core-mvc/code-snippet/spreadsheet/save-header/razor
@@ -20,6 +20,7 @@ function fileMenuItemSelect(args) {
         );
         formData.append("fileName", "Sample");
         formData.append("saveType", "Xlsx");
+        formData.append("pdfLayoutSettings", JSON.stringify({ fitSheetOnOnePage: false, orientation: "Portrait" }));
         fetch(
           "https://services.syncfusion.com/aspnet/production/api/spreadsheet/save",
           {

--- a/ej2-asp-core-mvc/code-snippet/spreadsheet/save-header/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/spreadsheet/save-header/tagHelper
@@ -22,6 +22,7 @@
         );
         formData.append("fileName", "Sample");
         formData.append("saveType", "Xlsx");
+        formData.append("pdfLayoutSettings", JSON.stringify({ fitSheetOnOnePage: false, orientation: "Portrait" }));
         fetch(
           "https://services.syncfusion.com/aspnet/production/api/spreadsheet/save",
           {


### PR DESCRIPTION
Query 1:
Need to correct the sample by adding the requestData with Authorization and not to assign the requestData as Authorization in the beforeOpen event provided in the below UG section,

https://ej2.syncfusion.com/react/documentation/spreadsheet/open-save#to-add-custom-header-during-open

Query 2:

Need to add the pdfLayoutSettings for the sample in the below UG section and ensure the working of sample,

https://ej2.syncfusion.com/react/documentation/spreadsheet/open-save#to-add-custom-header-during-save
