### PR TITLE
884073: Note section in standalone PDF Viewer is updated

### DIFF
--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/getting-started.md
@@ -134,10 +134,6 @@ N> You can refer to our [ASP.NET MVC PDF Viewer](https://www.syncfusion.com/aspn
 
 When comparing a Standalone PDF Viewer to a Server-Backed PDF Viewer control, it's crucial to understand the limitations that the Standalone PDF Viewer may have in comparison. These limitations are important to consider
 
-### PNG Image Support
-
-The Standalone PDF Viewer does not have the capability to utilize PNG format for adding images to handwritten annotations ,custom stamp ,signature and initial form fields. It's important to be aware that only certain image formats, such as JPEG, are compatible for these purposes.
-
 ### Local File Access
 
 * The Standalone PDF Viewer control does not have the capability to directly access and load local physical files from a user's device. As a result, it is not possible to use a documentPath to load a PDF file directly from a local server within the viewer.

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/getting-started.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/getting-started.md
@@ -138,10 +138,6 @@ N> [View Sample in GitHub](https://github.com/SyncfusionExamples/ASP-NET-Core-Ge
 
 When comparing a Standalone PDF Viewer to a Server-Backed PDF Viewer control, it's crucial to understand the limitations that the Standalone PDF Viewer may have in comparison. These limitations are important to consider
 
-### PNG Image Support
-
-The Standalone PDF Viewer does not have the capability to utilize PNG format for adding images to handwritten annotations ,custom stamp ,signature and initial form fields. It's important to be aware that only certain image formats, such as JPEG, are compatible for these purposes.
-
 ### Local File Access
 
 * The Standalone PDF Viewer control does not have the capability to directly access and load local physical files from a user's device. As a result, it is not possible to use a documentPath to load a PDF file directly from a local server within the viewer.


### PR DESCRIPTION
### Description 

The note section regarding limitations has been updated. The standalone PDF Viewer now includes support for PNG images, thus removing the limitation associated with PNG image compatibility.