### PR TITLE
889328: Need to move the web service link into 'services.syncfusion.com' from 'ej2services.syncfusion.com

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/additional-parameter/razor
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/additional-parameter/razor
@@ -1,5 +1,5 @@
             @Html.EJS().Kanban("kanban").KeyField("Status").AllowDragAndDrop(false).DataSource(dataManger =>
-       { dataManger.Url("https://ej2services.syncfusion.com/production/web-services/api/Kanban").CrossDomain(true);
+       { dataManger.Url("https://services.syncfusion.com/aspnet/production/api/Kanban").CrossDomain(true);
        }).Query("new ej.data.Query().addParams('ej2kanban', 'true')").Columns(col=> {
            col.HeaderText("To Do").KeyField("Open").Add();
            col.HeaderText("In Progress").KeyField("InProgress").Add();

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/additional-parameter/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/additional-parameter/tagHelper
@@ -1,5 +1,5 @@
  <ejs-kanban id="Kanban" keyField="Status" allowDragAndDrop="false" dialogOpen="dialogOpen"   query="new ej.data.Query().addParams('ej2kanban', 'true')" >
-                <e-data-manager url="https://ej2services.syncfusion.com/production/web-services/api/Kanban" crossdomain="true"></e-data-manager>
+                <e-data-manager url="https://services.syncfusion.com/aspnet/production/api/Kanban" crossdomain="true"></e-data-manager>
                 <e-kanban-columns>
                     <e-kanban-column headerText="To Do" keyField="Open"></e-kanban-column>
                     <e-kanban-column headerText="In Progress" keyField="InProgress"></e-kanban-column>

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/custom-adaptor/razor
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/custom-adaptor/razor
@@ -23,7 +23,7 @@
         }
         var kanban = document.querySelector('#kanban').ej2_instances[0];
         kanban.dataSource = new ej.data.DataManager({
-            url: "https://ej2services.syncfusion.com/production/web-services/api/Kanban",
+        url: "https://services.syncfusion.com/aspnet/production/api/Kanban",
             adaptor: new TaskIdAdaptor()
         });
     }

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/custom-adaptor/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/custom-adaptor/tagHelper
@@ -25,7 +25,7 @@
         }
         var kanban = document.querySelector('#kanban').ej2_instances[0];
         kanban.dataSource = new ej.data.DataManager({
-            url: "https://ej2services.syncfusion.com/production/web-services/api/Kanban",
+            url: "https://services.syncfusion.com/aspnet/production/api/Kanban",
             adaptor: new TaskIdAdaptor()
         });
     }

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/data-via-ajax/razor
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/data-via-ajax/razor
@@ -13,7 +13,7 @@
         var kanbanObj = this;
         var button = document.getElementById('btn');
         button.addEventListener("click", function (e) {
-            let ajax = new ej.base.Ajax("https://ej2services.syncfusion.com/production/web-services/api/Orders", "GET");
+        let ajax = new ej.base.Ajax("https://services.syncfusion.com/aspnet/production/api/Orders", "GET");
             ajax.send();
             ajax.onSuccess = function (data) {
                 kanbanObj.dataSource = JSON.parse(data);

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/data-via-ajax/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/data-via-ajax/tagHelper
@@ -13,7 +13,7 @@
         var kanbanObj = this;
         var button = document.getElementById('btn');
         button.addEventListener("click", function (e) {
-            let ajax = new ej.base.Ajax("https://ej2services.syncfusion.com/production/web-services/api/Orders", "GET");
+            let ajax = new ej.base.Ajax("https://services.syncfusion.com/aspnet/production/api/Orders", "GET");
             ajax.send();
             ajax.onSuccess = function (data) {
                 kanbanObj.dataSource = JSON.parse(data);

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/odata-service/razor
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/odata-service/razor
@@ -1,5 +1,5 @@
   @Html.EJS().Kanban("kanban").KeyField("Status").AllowDragAndDrop(false).DataSource(dataManger => {
-            dataManger.Url("https://ej2services.syncfusion.com/production/web-services/api/Kanban").CrossDomain(true).Adaptor("ODataAdaptor");
+            dataManger.Url("https://services.syncfusion.com/aspnet/production/api/Kanban").CrossDomain(true).Adaptor("ODataAdaptor");
             }).Columns(col=> {
            col.HeaderText("To Do").KeyField("Open").Add();
            col.HeaderText("In Progress").KeyField("InProgress").Add();

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/odata-v4-service/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/odata-v4-service/tagHelper
@@ -1,5 +1,5 @@
          <ejs-kanban id="Kanban" keyField="Status" allowDragAndDrop="false" dialogOpen="dialogOpen" >
-                <e-data-manager url="https://ej2services.syncfusion.com/production/web-services/api/Kanban"  adaptor="ODataAdaptor" crossdomain="true"></e-data-manager>
+                <e-data-manager url="https://services.syncfusion.com/aspnet/production/api/Kanban"  adaptor="ODataAdaptor" crossdomain="true"></e-data-manager>
                 <e-kanban-columns>
                     <e-kanban-column headerText="To Do" keyField="Open"></e-kanban-column>
                     <e-kanban-column headerText="In Progress" keyField="InProgress"></e-kanban-column>

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/remote-data/razor
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/remote-data/razor
@@ -1,5 +1,5 @@
  @Html.EJS().Kanban("kanban").KeyField("Status").AllowDragAndDrop(false).DataSource(dataManger =>
-       { dataManger.Url("https://ej2services.syncfusion.com/production/web-services/api/Kanban").CrossDomain(true);
+       { dataManger.Url("https://services.syncfusion.com/aspnet/production/api/Kanban").CrossDomain(true);
        }).Columns(col=> {
            col.HeaderText("To Do").KeyField("Open").Add();
            col.HeaderText("In Progress").KeyField("InProgress").Add();

--- a/ej2-asp-core-mvc/code-snippet/kanban/data-binding/remote-data/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/kanban/data-binding/remote-data/tagHelper
@@ -1,5 +1,5 @@
  <ejs-kanban id="Kanban" keyField="Status" allowDragAndDrop="false" dialogOpen="dialogOpen" >
-                <e-data-manager url="https://ej2services.syncfusion.com/production/web-services/api/Kanban" crossdomain="true"></e-data-manager>
+                <e-data-manager url="https://services.syncfusion.com/aspnet/production/api/Kanban" crossdomain="true"></e-data-manager>
                 <e-kanban-columns>
                     <e-kanban-column headerText="To Do" keyField="Open"></e-kanban-column>
                     <e-kanban-column headerText="In Progress" keyField="InProgress"></e-kanban-column>


### PR DESCRIPTION
### Bug description

Need to move the web service link into 'services.syncfusion.com' from 'ej2services.syncfusion.com

### Root Cause / Analysis

Updating the sample host URLs

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?

No

### Solution Description

Updating the sample host URLs

### Areas affected and ensured

Yes

### E2E report details against this fix

No

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner