### PR TITLE
889328: Need to move the web service link into 'services.syncfusion.com' from 'ej2services.syncfusion.com

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/file-browser/controller.cs
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/file-browser/controller.cs
@@ -2,7 +2,7 @@
 {
     public ActionResult Index()
     {
-        string hostUrl = "https://services.syncfusion.com/aspnet/production/";
+        string hostUrl = "https://ej2-aspcore-service.azurewebsites.net/";
         ViewBag.ajaxSettings = new {
             url = hostUrl + "api/FileManager/FileOperations",
             getImageUrl = hostUrl + "api/FileManager/GetImage",


### PR DESCRIPTION
### Bug description

Need to move the web service link into 'services.syncfusion.com' from 'ej2services.syncfusion.com

### Root Cause / Analysis

Updating the sample host URLs

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?

No

### Solution Description

Updating the sample host URLs

### Areas affected and ensured

Yes

### E2E report details against this fix

No

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner