### PR TITLE
890543: To update the getting started documentation page in the Rich text editor component in JS, TS, Core, and MVC platforms

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/basic/default/razor
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/basic/default/razor
@@ -1,4 +1,4 @@
-@Html.EJS().RichTextEditor("defaultRTE").ContentTemplate(@<div>
+@Html.EJS().RichTextEditor("editor").ContentTemplate(@<div>
     <div>
         <p>The Rich Text Editor is WYSIWYG ('what you see is what you get') editor useful to create and edit content, and return the valid <a href='https://ej2.syncfusion.com/aspnetmvc/RichTextEditor/Overview'>HTML markup</a> or <a href='https://ej2.syncfusion.com/aspnetmvc/RichTextEditor/DefaultMode'>markdown</a> of the content</p>
         <p><b> Toolbar </b></p>

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/basic/default/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/basic/default/tagHelper
@@ -1,4 +1,4 @@
-<ejs-richtexteditor id="defaultRTE">
+<ejs-richtexteditor id="editor">
     <e-content-template>
         <div>
             <p>The Rich Text Editor is WYSIWYG ('what you see is what you get') editor useful to create and edit content, and return the valid <a href='https://ej2.syncfusion.com/aspnetcore/RichTextEditor/Overview'>HTML markup</a> or <a href='https://ej2.syncfusion.com/aspnetcore/RichTextEditor/DefaultMode'>markdown</a> of the content</p>

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/getting-started.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/getting-started.md
@@ -51,7 +51,7 @@ Add **Syncfusion.EJ2** namespace reference in `Web.config` under `Views` folder.
 
 ## Add stylesheet and script resources
 
-Here, the theme and script is referred using CDN inside the `<head>` of `~/Pages/Shared/_Layout.cshtml` file as follows,
+Here, the theme and script is referred using CDN inside the `<head>` of `~/Views/Shared/_Layout.cshtml` file as follows,
 
 {% tabs %}
 {% highlight cshtml tabtitle="~/_Layout.cshtml" %}
@@ -71,7 +71,7 @@ N> Checkout the [Themes topic](https://ej2.syncfusion.com/aspnetmvc/documentatio
 
 ## Register Syncfusion script manager
 
-Also, register the script manager `EJS().ScriptManager()` at the end of `<body>` in the `~/Pages/Shared/_Layout.cshtml` file as follows.
+Also, register the script manager `EJS().ScriptManager()` at the end of `<body>` in the `~/Views/Shared/_Layout.cshtml` file as follows.
 
 {% tabs %}
 {% highlight cshtml tabtitle="~/_Layout.cshtml" %}
@@ -98,18 +98,6 @@ Now, add the Syncfusion ASP.NET MVC Rich Text Editor control in `~/Views/Home/In
 Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the app. Then, the Syncfusion ASP.NET MVC Rich Text Editor control will be rendered in the default web browser.
 
 ![ASP.NET MVC Rich Text Editor Control](images/richtexteditor-control.png)
-
-### Initialize from iframe element
-
-Initialize the Rich Text Editor on `<div>` element as shown below and set the enable field of [IframeSettings](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditor.html#Syncfusion_EJ2_RichTextEditor_RichTextEditor_IframeSettings) property as true to render the Rich Text Editor content in an `<iframe>` and its isolated from the rest of the page.
-
-{% tabs %}
-{% highlight razor tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/iframe/razor %}
-{% endhighlight %}
-{% endtabs %}
-
-![ASP.NET MVC Rich Text Editor with IFrame Element](images/richtexteditor-iframe-element.png)
 
 ## Configure the Toolbar
 
@@ -139,102 +127,6 @@ public ActionResult Index()
 ![ASP.NET Rich Text Editor with Toolbar](images/richtexteditor-with-toolbar.png)
 
 N> `|` and `-` can insert a vertical and horizontal separator lines in the toolbar.
-
-## Insert Images and Links
-
-The `Image` module inserts an image into Rich Text Editor’s content area, and the `Link` module links external resources such as website URLs, to selected text in the Rich Text Editor’s content, respectively.
-
-The link inject module adds a link icon to the toolbar and the image inject module adds an image icon to the toolbar.
-
-Specifies the items to be rendered in quick toolbar based on the target element such image, link and text element. The quick toolbar opens to customize the element by clicking the target element.
-
-{% tabs %}
-{% highlight razor tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/image/razor %}
-{% endhighlight %}
-{% highlight c# tabtitle="HomeController.cs" %}
-public ActionResult Index()
-{
-    ViewBag.image = new[] {
-        "Replace", "Align", "Caption", "Remove", "InsertLink", "OpenImageLink", "-",
-        "EditImageLink", "RemoveImageLink", "Display", "AltText", "Dimension"
-    };
-    List<string> tools = new List<string>() {
-        "Bold", "Italic", "Underline", "StrikeThrough",
-        "FontName", "FontSize", "FontColor", "BackgroundColor",
-        "LowerCase", "UpperCase", "|",
-        "Formats", "Alignments", "OrderedList", "UnorderedList",
-        "Outdent", "Indent", "|",
-        "CreateLink", "Image", "CreateTable", "|", "ClearFormat", "Print",
-        "SourceCode", "FullScreen", "|", "Undo", "Redo"
-    };
-    return View(tools);
-}
-{% endhighlight %}
-{% endtabs %}
-
-![ASP.NET MVC Rich Text Editor with Image](images/richtexteditor-with-image.png)
-
-## Send formatted content using XmlHttpRequest
-
-The Html string of the Rich Text Editor can be passed from View to the Controller through the `XMLHttpRequest` `Post` action. The HTML value binds to the corresponding mapped controller, and you can access it in the Post action parameter.
-
-{% tabs %}
-{% highlight razor tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/rtevalue/razor %}
-{% endhighlight %}
-{% endtabs %}
-
-## Retrieve the Formatted Content
-
-To retrieve the editor contents, use [value](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditor.html#Syncfusion_EJ2_RichTextEditor_RichTextEditor_Value) property of Rich Text Editor.
-
-```javascript
-  var rteValue = this.rteObj.value;
-```
-
-Or, you can use the public method, `getHtml` to retrieve the Rich Text Editor content.
-
-```javascript
-  var rteValue = this.rteObj.getHtml();
-```
-
-To fetch the Rich Text Editor's text content, use `getText` method of Rich Text Editor.
-
-```javascript
-  var rteValue = this.rteObj.getText();
-```
-
-## Retrieve the number of characters
-
-To get the maximum number of characters in the Rich Text Editor's content, use `getCharCount`
-
-```typescript
-  let rteCount = this.rteObj.getCharCount();
-```
-
-The final output will be displayed as follows
-
-{% tabs %}
-{% highlight razor tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/link/razor %}
-{% endhighlight %}
-{% highlight c# tabtitle="HomeController.cs" %}
-public ActionResult Index()
-{
-    List<string> tools = new List<string>() {
-        "Bold", "Italic", "Underline", "StrikeThrough",
-        "FontName", "FontSize", "FontColor", "BackgroundColor",
-        "LowerCase", "UpperCase", "|",
-        "Formats", "Alignments", "OrderedList", "UnorderedList",
-        "Outdent", "Indent", "|",
-        "CreateLink", "Image", "CreateTable", "|", "ClearFormat", "Print",
-        "SourceCode", "FullScreen", "|", "Undo", "Redo"
-    };
-    return View(tools);
-}
-{% endhighlight %}
-{% endtabs %}
 
 N> [View Sample in GitHub](https://github.com/SyncfusionExamples/ASP-NET-MVC-Getting-Started-Examples/tree/main/RichTextEditor/ASP.NET%20MVC%20Razor%20Examples).
 

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/getting-started.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/getting-started.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with ##Platform_Name## Rich Text Editor Control
+title: Getting Started with ##Platform_Name## Rich Text Editor Control | Syncfusion
 description: Checkout and learn about getting started with ##Platform_Name## Rich Text Editor control of Syncfusion Essential JS 2 and more details.
 platform: ej2-asp-core-mvc
 control: Getting Started

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/getting-started.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/getting-started.md
@@ -100,18 +100,6 @@ Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (m
 
 ![ASP.NET Core RichTextEditor Control](images/richtexteditor-control.png)
 
-### Initialize from iframe element
-
-Initialize the Rich Text Editor on `<div>` element as shown below and set the `enable` field of [`iframeSettings`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditor.html#Syncfusion_EJ2_RichTextEditor_RichTextEditor_IframeSettings) property as true to render the Rich Text Editor content in an `<iframe>` and its isolated from the rest of the page.
-
-{% tabs %}
-{% highlight cshtml tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/iframe/tagHelper %}
-{% endhighlight %}
-{% endtabs %}
-
-![ASP.NET Core RichTextEditor with Iframe Element](images/richtexteditor-iframe-element.png)
-
 ## Configure the Toolbar
 
 Configure the toolbar with the tools using items field of the [`toolbarSettings`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditor.html#Syncfusion_EJ2_RichTextEditor_RichTextEditor_ToolbarSettings) property as your application requires.
@@ -125,72 +113,6 @@ Configure the toolbar with the tools using items field of the [`toolbarSettings`
 ![ASP.NET Core RichTextEditor with Toolbar](images/richtexteditor-with-toolbar.png)
 
 N> `|` and `-` can insert a vertical and horizontal separator lines in the toolbar.
-
-## Insert Images and Links
-
-The `Image` module inserts an image into RichTextEditor’s content area, and the `Link` module links external resources such as website URLs, to selected text in the RichTextEditor’s content, respectively.
-
-The link inject module adds a link icon to the toolbar and the image inject module adds an image icon to the toolbar.
-
-Specifies the items to be rendered in quick toolbar based on the target element such image, link and text element. The quick toolbar opens to customize the element by clicking the target element.
-
-{% tabs %}
-{% highlight cshtml tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/image/tagHelper %}
-{% endhighlight %}
-{% endtabs %}
-
-## Send formatted content using XmlHttpRequest
-
-The Html string of the Rich Text Editor can be passed from View to the Controller through the `XMLHttpRequest` `Post` action. The HTML value binds to the corresponding mapped controller, and you can access it in the Post action parameter.
-
-{% tabs %}
-{% highlight cshtml tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/rtevalue/tagHelper %}
-{% endhighlight %}
-{% highlight c# tabtitle="CSHTML.cs" %}
-public class RichTextEditorValue
-{
-    public string text { get; set; }
-}
-{% endhighlight %}
-{% endtabs %}
-
-## Retrieve the Formatted Content
-
-To retrieve the editor contents, use [`value`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditor.html#Syncfusion_EJ2_RichTextEditor_RichTextEditor_Value) property of Rich Text Editor.
-
-```javascript
-  var rteValue = this.rteObj.value;
-```
-
-Or, you can use the public method, `getHtml` to retrieve the Rich Text Editor content.
-
-```javascript
-  var rteValue = this.rteObj.getHtml();
-```
-
-To fetch the Rich Text Editor's text content, use `getText` method of Rich Text Editor.
-
-```javascript
-  var rteValue = this.rteObj.getText();
-```
-
-## Retrieve the number of characters
-
-To get the maximum number of characters in the Rich Text Editor's content, use `getCharCount`
-
-```typescript
-  let rteCount = this.rteObj.getCharCount();
-```
-
-The final output will be displayed as follows
-
-{% tabs %}
-{% highlight cshtml tabtitle="CSHTML" %}
-{% include code-snippet/rich-text-editor/basic/link/tagHelper %}
-{% endhighlight %}
-{% endtabs %}
 
 N> [View Sample in GitHub](https://github.com/SyncfusionExamples/ASP-NET-Core-Getting-Started-Examples/tree/main/RichTextEditor/ASP.NET%20Core%20Tag%20Helper%20Examples).
 

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/getting-started.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with ##Platform_Name## RichTextEditor Control
-description: Checkout and learn about getting started with ##Platform_Name## RichTextEditor control of Syncfusion Essential JS 2 and more details.
+title: Getting Started with ##Platform_Name## Rich Text Editor Control
+description: Checkout and learn about getting started with ##Platform_Name## Rich Text Editor control of Syncfusion Essential JS 2 and more details.
 platform: ej2-asp-core-mvc
 control: Getting Started
 publishingplatform: ##Platform_Name##
@@ -9,9 +9,9 @@ documentation: ug
 ---
 
 
-# Getting Started with ASP.NET Core RichTextEditor Control
+# Getting Started with ASP.NET Core Rich Text Editor Control
 
-This section briefly explains about how to include [ASP.NET Core RichTextEditor](https://www.syncfusion.com/aspnet-core-ui-controls/wysiwyg-rich-text-editor) control in your ASP.NET Core application using Visual Studio.
+This section briefly explains about how to include [ASP.NET Core Rich Text Editor](https://www.syncfusion.com/aspnet-core-ui-controls/wysiwyg-rich-text-editor) control in your ASP.NET Core application using Visual Studio.
 
 ## Prerequisites
 
@@ -86,9 +86,9 @@ Also, register the script manager `<ejs-script>` at the end of `<body>` in the A
 {% endhighlight %}
 {% endtabs %}
 
-## Add ASP.NET Core RichTextEditor control
+## Add ASP.NET Core Rich Text Editor control
 
-Now, add the Syncfusion ASP.NET Core RichTextEditor tag helper in `~/Pages/Index.cshtml` page.
+Now, add the Syncfusion ASP.NET Core Rich Text Editor tag helper in `~/Pages/Index.cshtml` page.
 
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
@@ -96,9 +96,9 @@ Now, add the Syncfusion ASP.NET Core RichTextEditor tag helper in `~/Pages/Index
 {% endhighlight %}
 {% endtabs %}
 
-Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the app. Then, the Syncfusion ASP.NET Core RichTextEditor control will be rendered in the default web browser.
+Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the app. Then, the Syncfusion ASP.NET Core Rich Text Editor control will be rendered in the default web browser.
 
-![ASP.NET Core RichTextEditor Control](images/richtexteditor-control.png)
+![ASP.NET Core Rich Text Editor Control](images/richtexteditor-control.png)
 
 ## Configure the Toolbar
 
@@ -110,7 +110,7 @@ Configure the toolbar with the tools using items field of the [`toolbarSettings`
 {% endhighlight %}
 {% endtabs %}
 
-![ASP.NET Core RichTextEditor with Toolbar](images/richtexteditor-with-toolbar.png)
+![ASP.NET Core Rich Text Editor with Toolbar](images/richtexteditor-with-toolbar.png)
 
 N> `|` and `-` can insert a vertical and horizontal separator lines in the toolbar.
 


### PR DESCRIPTION
### Bug description
To update documentation for the getting started in the Rich Text Editor for all platforms
### Root Cause / Analysis


### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?
No

### Solution Description


### Areas affected and ensured

No

### E2E report details against this fix

No

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner