### PR TITLE
903423: Make a Slash menu documentation for the Rich Text Editor.

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/controller.cs
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/controller.cs
@@ -1,0 +1,34 @@
+public class HomeController : Controller
+{
+    public ActionResult Index()
+    {
+        ViewBag.items = new[] {  "Bold", "Italic", "Underline", "StrikeThrough", "SuperScript", "SubScript", "|",
+        "FontName", "FontSize", "FontColor", "BackgroundColor", "|",
+        "LowerCase", "UpperCase",
+        "Formats", "Alignments", "|", "NumberFormatList", "BulletFormatList", "|",
+        "Outdent", "Indent", "|",
+        "CreateLink", "Image", "Video", "Audio", "CreateTable", "|", "FormatPainter", "ClearFormat", "|", "EmojiPicker", "|",
+        "SourceCode", "|", "Undo", "Redo" };
+        return View();
+        RichTextEditorSlashMenuSettings SlashMenuSettings = new RichTextEditorSlashMenuSettings
+        {
+        Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3", "Heading 4", "OrderedList", "UnorderedList",
+                    "CodeBlock", "Blockquote", "Link", "Image", "Video", "Audio", "Table", "Emojipicker",
+                    new {
+                        text= "Meeting notes",
+                        description= "Insert a meeting note template.",
+                        iconCss= "e-icons e-description",
+                        type= "Custom",
+                        command= "MeetingNotes"
+                    },
+                    new {
+                        text= "Signature",
+                        description= "Insert a signature template.",
+                        iconCss= "e-icons e-signature",
+                        type= "Custom",
+                        command= "Signature"
+                    }               
+            }
+        }
+    }
+}

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/controller.cs
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/controller.cs
@@ -9,10 +9,10 @@ public class HomeController : Controller
         "Outdent", "Indent", "|",
         "CreateLink", "Image", "Video", "Audio", "CreateTable", "|", "FormatPainter", "ClearFormat", "|", "EmojiPicker", "|",
         "SourceCode", "|", "Undo", "Redo" };
-        return View();
-        RichTextEditorSlashMenuSettings SlashMenuSettings = new RichTextEditorSlashMenuSettings
-        {
-        Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3", "Heading 4", "OrderedList", "UnorderedList",
+         ViewBag.SlashMenuSettings = new Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings
+            {
+                Enable = true,
+                Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3", "Heading 4", "OrderedList", "UnorderedList",
                     "CodeBlock", "Blockquote", "Link", "Image", "Video", "Audio", "Table", "Emojipicker",
                     new {
                         text= "Meeting notes",
@@ -27,8 +27,9 @@ public class HomeController : Controller
                         iconCss= "e-icons e-signature",
                         type= "Custom",
                         command= "Signature"
-                    }               
+                    }
+                }
             }
-        }
+        return View();
     }
 }

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/razor
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/razor
@@ -1,0 +1,17 @@
+@Html.EJS().RichTextEditor("slashMenu").Placeholder("Type '/' and choose format").Created("created").ToolbarSettings(e => e.Items((object)ViewBag.items)).SlashMenuSettings(ViewBag.SlashMenuSettings).SlashMenuItemSelect("slashMenuItemSelect").Render()
+<script>
+    var rteObj;
+    const meetingNotes = '<p><strong>Meeting Notes</strong></p><table class="e-rte-table" style="width: 100%; min-width: 0px; height: 150px;"> <tbody> <tr style="height: 20%;"> <td style="width: 50%;"><strong>Attendees</strong></td> <td style="width: 50%;" class=""><br></td> </tr> <tr style="height: 20%;"> <td style="width: 50%;"><strong>Date &amp; Time</strong></td> <td style="width: 50%;"><br></td> </tr> <tr style="height: 20%;"> <td style="width: 50%;"><strong>Agenda</strong></td> <td style="width: 50%;"><br></td> </tr> <tr style="height: 20%;"> <td style="width: 50%;"><strong>Discussed Items</strong></td> <td style="width: 50%;"><br></td> </tr> <tr style="height: 20%;"> <td style="width: 50%;"><strong>Action Items</strong></td> <td style="width: 50%;"><br></td> </tr> </tbody> </table>';
+    const signature = '<p><br></p><p>Warm regards,</p><p>John Doe<br>Event Coordinator<br>ABC Company</p>';
+    function created() {
+        rteObj = this;
+    }
+   function slashMenuItemSelect(args) {
+    if (args.itemData.command === "MeetingNotes") {
+      rteObj.executeCommand("insertHTML", meetingNotes, { undo: true });
+    }
+    if (args.itemData.command === "Signature") {
+      rteObj.executeCommand("insertHTML", signature, { undo: true });
+    }
+  }
+</script>

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/slashmenu/tagHelper
@@ -1,0 +1,25 @@
+<ejs-richtexteditor id="slashMenu" created="created" slashMenuItemSelect="slashMenuItemSelect"
+            placeholder="Type '/' and choose format">
+            <e-richtexteditor-toolbarsettings items="@ViewBag.items"></e-richtexteditor-toolbarsettings>
+            <e-richtexteditor-slashmenusettings enable="true"
+                items="@SlashMenuSettings.Items"></e-richtexteditor-slashmenusettings>
+</ejs-richtexteditor>
+
+<script type="text/javascript">
+    var rteObj;
+    const meetingNotes = '<p><strong>Meeting Notes</strong></p><table class="e-rte-table" style="width: 100%; min - width: 0px; height: 150px; "> <tbody> <tr style="height: 20%; "> <td style="width: 50%; "><strong>Attendees</strong></td> <td style="width: 50%; " class=""><br></td> </tr> <tr style="height: 20%; "> <td style="width: 50%; "><strong>Date &amp; Time</strong></td> <td style="width: 50%; "><br></td> </tr> <tr style="height: 20%; "> <td style="width: 50%; "><strong>Agenda</strong></td> <td style="width: 50%; "><br></td> </tr> <tr style="height: 20%; "> <td style="width: 50%; "><strong>Discussed Items</strong></td> <td style="width: 50%; "><br></td> </tr> <tr style="height: 20%; "> <td style="width: 50%; "><strong>Action Items</strong></td> <td style="width: 50%; "><br></td> </tr> </tbody> </table>';
+
+    const signature = '<p><br></p><p>Warm regards,</p><p>John Doe<br>Event Coordinator<br>ABC Company</p>';
+
+    function created() {
+        rteObj = this;
+    }
+    function slashMenuItemSelect(args) {
+        if (args.itemData.command === "MeetingNotes") {
+            rteObj.executeCommand("insertHTML", meetingNotes, { undo: true });
+        }
+        if (args.itemData.command === "Signature") {
+            rteObj.executeCommand("insertHTML", signature, { undo: true });
+        }
+    }
+</script>

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
@@ -66,6 +66,8 @@ Each custom item object can include the following properties:
 
 The following code demonstrates how to set up the Custom Slash Menu item in the Rich Text Editor to insert meeting notes and signature:
 
+{% if page.publishingplatform == "aspnet-core" %}
+
 {% tabs %}
 {% highlight cshtml tabtitle="CSHTML" %}
 {% include code-snippet/rich-text-editor/slashmenu/tagHelper %}

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
@@ -15,7 +15,7 @@ The Slash Menu in the Rich Text Editor provides users with an efficient way to a
 
 ## Enabling the Slash Menu
 
-To enable the Slash Menu, set the `Enable` property within [`slashMenuSettings`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the Slash Menu will appear when the user types the "/" character in the editor.
+To enable the Slash Menu, set the `Enable` property within [`SlashMenuSettings`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the Slash Menu will appear when the user types the "/" character in the editor.
 
 ## Configuring the Slash Menu Items
 

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Slash Menu in ##Platform_Name## Rich Text Editor Component
+title: Slash Menu in ##Platform_Name## Rich Text Editor Component | Syncfusion
 description: Learn here all about Slash Menu in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Slash Menu

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
@@ -1,0 +1,89 @@
+---
+layout: post
+title: Slash Menu in ##Platform_Name## Rich Text Editor Component
+description: Learn here all about Slash Menu in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
+platform: ej2-asp-core-mvc
+control: Slash Menu
+publishingplatform: ##Platform_Name##
+documentation: ug
+---
+
+
+# Slash Menu in the ##Platform_Name## Rich Text Editor component
+
+The Slash Menu in the Rich Text Editor provides users with an efficient way to apply formatting, insert elements, and execute custom commands by simply typing the "/" character. This feature enhances the user experience by offering quick access to common editing actions within the editor.
+
+## Enabling the Slash Menu
+
+To enable the Slash Menu, set the `Enable` property within [`slashMenuSettings`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the Slash Menu will appear when the user types the "/" character in the editor.
+
+## Configuring the Slash Menu Items
+
+The slashMenuSettings property allows customization of the `Items` displayed in the Slash Menu. By defining the [`Items`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorSlashMenuSettings_Items) property, a list of available commands can be provided for users to choose from when they type a slash (/) in the Rich Text Editor.
+
+This list can include various formatting options such as paragraph and heading levels. Here’s an code snippet of configuring the Slash Menu items:
+
+```
+ViewBag.SlashMenuSettings = new Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings
+{
+    Enable = true,
+    Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3" },
+};
+
+```
+
+## Customizing the Popup Width and Height
+
+The size of the Slash Menu popup can be customized using the [`PopupWidth`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorSlashMenuSettings_PopupWidth) and [`PopupHeight`](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorSlashMenuSettings_PopupHeight) properties within slashMenuSettings. Adjusting these values allows for control over the dimensions of the menu. 
+
+Below is an code snippet showing how to customize both the width and height of the popup:
+
+```
+ViewBag.SlashMenuSettings = new Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings
+{
+    Enable = true,
+    Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3" },
+    PopupHeight = "300px",
+    PopupWidth = "250px"
+};
+
+
+```
+
+## Adding Custom Slash Menu Items
+
+Custom items can be added by defining the items property inside slashMenuSettings. This property accepts either a string of predefined items or an array of objects representing custom menu items.
+
+Each custom item object can include the following properties:
+
+| Property    | Description                                           |
+|-------------|-------------------------------------------------------|
+| text        | The label of the menu item.                           |
+| command     | The action to be executed when the item is clicked.   |
+| type        | Groups related items in the Slash Menu.               |
+| iconCss     | Specifies the CSS class for the item's icon.          |
+| description | Provides a short description for the item.            |
+ 
+
+The following code demonstrates how to set up the Custom Slash Menu item in the Rich Text Editor to insert meeting notes and signature:
+
+{% tabs %}
+{% highlight cshtml tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/slashmenu/tagHelper %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/slashmenu/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+{% tabs %}
+{% highlight razor tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/slashmenu/razor %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/slashmenu/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+{% endif %}

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/slash-menu.md
@@ -47,7 +47,6 @@ ViewBag.SlashMenuSettings = new Syncfusion.EJ2.RichTextEditor.RichTextEditorSlas
     PopupWidth = "250px"
 };
 
-
 ```
 
 ## Adding Custom Slash Menu Items

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/slash-menu.md
@@ -15,7 +15,7 @@ The Slash Menu in the Rich Text Editor provides users with an efficient way to a
 
 ## Enabling the Slash Menu
 
-To enable the Slash Menu, set the `Enable` property within [`slashMenuSettings`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the Slash Menu will appear when the user types the "/" character in the editor.
+To enable the Slash Menu, set the `Enable` property within [`SlashMenuSettings`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the Slash Menu will appear when the user types the "/" character in the editor.
 
 ## Configuring the Slash Menu Items
 

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/slash-menu.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Slash Menu in ##Platform_Name## Rich Text Editor Component
+title: Slash Menu in ##Platform_Name## Rich Text Editor Component | Syncfusion
 description: Learn here all about Slash Menu in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Slash Menu

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/slash-menu.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/slash-menu.md
@@ -1,0 +1,104 @@
+---
+layout: post
+title: Slash Menu in ##Platform_Name## Rich Text Editor Component
+description: Learn here all about Slash Menu in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
+platform: ej2-asp-core-mvc
+control: Slash Menu
+publishingplatform: ##Platform_Name##
+documentation: ug
+---
+
+
+# Slash Menu in the ##Platform_Name## Rich Text Editor component
+
+The Slash Menu in the Rich Text Editor provides users with an efficient way to apply formatting, insert elements, and execute custom commands by simply typing the "/" character. This feature enhances the user experience by offering quick access to common editing actions within the editor.
+
+## Enabling the Slash Menu
+
+To enable the Slash Menu, set the `Enable` property within [`slashMenuSettings`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the Slash Menu will appear when the user types the "/" character in the editor.
+
+## Configuring the Slash Menu Items
+
+The slashMenuSettings property allows customization of the `Items` displayed in the Slash Menu. By defining the [`Items`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorSlashMenuSettings_Items) property, a list of available commands can be provided for users to choose from when they type a slash (/) in the Rich Text Editor.
+
+This list can include various formatting options such as paragraph and heading levels. Here’s an code snippet of configuring the Slash Menu items:
+
+```
+// Define the settings for the Rich Text Editor's slash menu
+RichTextEditorSlashMenuSettings SlashMenuSettings = new RichTextEditorSlashMenuSettings
+{
+    Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3" },
+};
+
+// Render the Rich Text Editor with the defined slash menu settings
+<ejs-richtexteditor>
+    <e-richtexteditor-slashmenusettings enable="true" items="@SlashMenuSettings.Items">
+    </e-richtexteditor-slashmenusettings>
+</ejs-richtexteditor>
+
+```
+
+## Customizing the Popup Width and Height
+
+The size of the Slash Menu popup can be customized using the [`PopupWidth`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorSlashMenuSettings_PopupWidth) and [`PopupHeight`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorSlashMenuSettings_PopupHeight) properties within slashMenuSettings. Adjusting these values allows for control over the dimensions of the menu. 
+
+Below is an code snippet showing how to customize both the width and height of the popup:
+
+```
+
+// Define the settings for the Rich Text Editor's slash menu
+RichTextEditorSlashMenuSettings SlashMenuSettings = new RichTextEditorSlashMenuSettings
+{
+    Items = new object[] { "Paragraph", "Heading 1", "Heading 2", "Heading 3" },
+    PopupHeight = "300px",  // Set the height of the popup
+    PopupWidth = "250px"    // Set the width of the popup
+};
+
+// Render the Rich Text Editor with the defined slash menu settings
+<ejs-richtexteditor>
+    <e-richtexteditor-slashmenusettings enable="true" items="@SlashMenuSettings.Items" popupHeight="@SlashMenuSettings.PopupHeight" 
+    popupWidth="@SlashMenuSettings.PopupWidth">
+    </e-richtexteditor-slashmenusettings>
+</ejs-richtexteditor>
+
+```
+
+## Adding Custom Slash Menu Items
+
+Custom items can be added by defining the items property inside slashMenuSettings. This property accepts either a string of predefined items or an array of objects representing custom menu items.
+
+Each custom item object can include the following properties:
+
+| Property    | Description                                           |
+|-------------|-------------------------------------------------------|
+| text        | The label of the menu item.                           |
+| command     | The action to be executed when the item is clicked.   |
+| type        | Groups related items in the Slash Menu.               |
+| iconCss     | Specifies the CSS class for the item's icon.          |
+| description | Provides a short description for the item.            |
+ 
+
+The following code demonstrates how to set up the Custom Slash Menu item in the Rich Text Editor to insert meeting notes and signature:
+
+{% if page.publishingplatform == "aspnet-core" %}
+
+{% tabs %}
+{% highlight cshtml tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/slashmenu/tagHelper %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/slashmenu/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+{% tabs %}
+{% highlight razor tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/slashmenu/razor %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/slashmenu/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+{% endif %}

--- a/ej2-asp-core-toc.html
+++ b/ej2-asp-core-toc.html
@@ -2275,7 +2275,7 @@
 		<li><a href="/ej2-asp-core/rich-text-editor/inline-mode">Inline Mode</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/paste-cleanup">Paste from MS Word</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/mention-integration">Mention Integration</a></li>
-		<li><a href="/ej2-asp-core/rich-text-editor/slash-menu.md">Slash Menu</a></li>
+		<li><a href="/ej2-asp-core/rich-text-editor/slash-menu">Slash Menu</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/enter-key">Enter and Shift-Enter Key's Customization</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/iframe">Iframe Rendering</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/style">Style and appearance</a></li>

--- a/ej2-asp-core-toc.html
+++ b/ej2-asp-core-toc.html
@@ -2275,7 +2275,7 @@
 		<li><a href="/ej2-asp-core/rich-text-editor/inline-mode">Inline Mode</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/paste-cleanup">Paste from MS Word</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/mention-integration">Mention Integration</a></li>
-		<li><a href="/ej2-asp-core/rich-text-editor/slash-menu">Slash Menu</a></li>
+		<li><a href="/ej2-asp-core/rich-text-editor/slash-menu.md">Slash Menu</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/enter-key">Enter and Shift-Enter Key's Customization</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/iframe">Iframe Rendering</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/style">Style and appearance</a></li>

--- a/ej2-asp-core-toc.html
+++ b/ej2-asp-core-toc.html
@@ -2275,6 +2275,7 @@
 		<li><a href="/ej2-asp-core/rich-text-editor/inline-mode">Inline Mode</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/paste-cleanup">Paste from MS Word</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/mention-integration">Mention Integration</a></li>
+		<li><a href="/ej2-asp-core/rich-text-editor/slash-menu">Slash Menu</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/enter-key">Enter and Shift-Enter Key's Customization</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/iframe">Iframe Rendering</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/style">Style and appearance</a></li>

--- a/ej2-asp-mvc-toc.html
+++ b/ej2-asp-mvc-toc.html
@@ -2233,6 +2233,7 @@
 		<li><a href="/ej2-asp-mvc/rich-text-editor/inline-mode">Inline Mode</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/paste-cleanup">Paste from MS Word</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/mention-integration">Mention Integration</a></li>
+		<li><a href="/ej2-asp-mvc/rich-text-editor/slash-menu">Slash Menu</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/enter-key">Enter and Shift-Enter Key's Customization</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/iframe">Iframe Rendering</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/exec-command">ExecCommand in Rich Text Editor</a></li>

--- a/ej2-asp-mvc-toc.html
+++ b/ej2-asp-mvc-toc.html
@@ -2233,7 +2233,7 @@
 		<li><a href="/ej2-asp-mvc/rich-text-editor/inline-mode">Inline Mode</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/paste-cleanup">Paste from MS Word</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/mention-integration">Mention Integration</a></li>
-		<li><a href="/ej2-asp-mvc/rich-text-editor/slash-menu.md">Slash Menu</a></li>
+		<li><a href="/ej2-asp-mvc/rich-text-editor/slash-menu">Slash Menu</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/enter-key">Enter and Shift-Enter Key's Customization</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/iframe">Iframe Rendering</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/exec-command">ExecCommand in Rich Text Editor</a></li>

--- a/ej2-asp-mvc-toc.html
+++ b/ej2-asp-mvc-toc.html
@@ -2233,7 +2233,7 @@
 		<li><a href="/ej2-asp-mvc/rich-text-editor/inline-mode">Inline Mode</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/paste-cleanup">Paste from MS Word</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/mention-integration">Mention Integration</a></li>
-		<li><a href="/ej2-asp-mvc/rich-text-editor/slash-menu">Slash Menu</a></li>
+		<li><a href="/ej2-asp-mvc/rich-text-editor/slash-menu.md">Slash Menu</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/enter-key">Enter and Shift-Enter Key's Customization</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/iframe">Iframe Rendering</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/exec-command">ExecCommand in Rich Text Editor</a></li>


### PR DESCRIPTION
### Bug description
Make a Slash menu documentation for the Rich Text Editor.

### Root Cause / Analysis
Need to create a slash menu documentation.

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?
No

### Solution Description
Created a slash menu documentation.

### Areas affected and ensured

No

### E2E report details against this fix

No

### Did you included unit test cases.?

NA

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner