### PR TITLE
914538: To add documentation for Import/export feature in all the platform except angular

### DIFF
--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/export/controller.cs
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/export/controller.cs
@@ -1,0 +1,32 @@
+public class HomeController : Controller
+{
+
+    public ActionResult Index()
+    {
+       ViewBag.Value = "<h2 style=\"text-align: center;\">Invitation to Microsoft Webinar Meet-Up</h2><p> Dear Guest, </p><p> We're thrilled to extend a special invitation to you for an exclusive Microsoft webinar meet-up, where we'll explore the latest innovations and insights driving the future of technology. As a valued member of our community, we believe this event will offer invaluable knowledge and networking opportunities. </p><h2>Event Details:</h2><table class=\"e-rte-table\" style=\"width: 100%; height: 125px;\"> <tbody> <tr style=\"height: 20%;\"> <th class=\"\">Time:</th> <td>10:00 AM - 12:00 PM</td> </tr> <tr style=\"height: 20%;\"> <th>Duration:</th> <td>2 hours</td> </tr> <tr style=\"height: 20%;\"> <th>Platform:</th> <td>Microsoft Teams</td> </tr> </tbody></table><p><br></p><h2>Agenda:</h2><ul> <li>Introduction to Cutting-Edge Microsoft Technologies</li> <li>Deep Dive into AI in Business: Leveraging Microsoft Azure Solutions</li> <li>Live Q&amp;A Session with Industry Experts</li> <li>Networking Opportunities with Peers and Professionals</li> </ul><h2>Why Attend?</h2><ul> <li>Gain insights into the latest trends and advancements in technology.</li> <li>Interact with industry experts and expand your professional network.</li> <li>Get your questions answered in real-time during the live Q&amp;A session.</li> <li>Access exclusive resources and offers available only to webinar attendees.</li> </ul><p> Feel free to invite your colleagues and peers who might benefit from this enriching experience. Simply forward this email to them or share the event details. </p><p> We're looking forward to your participation and to exploring the exciting world of Microsoft technology together. Should you have any questions or require further information, please don't hesitate to contact us at <a href=\"mailto:webinar@company.com\">webinar@company.com</a>.</p><p> <br></p><p>Warm regards,</p><p>John Doe<br>Event Coordinator<br>ABC Company</p>";
+       ViewBag.items = new[] { "Undo", "Redo", "|", "ExportWord", "ExportPdf", "|", "Bold", "Italic", "Underline", "StrikeThrough", "|",
+        "FontName", "FontSize", "FontColor", "BackgroundColor", "|",
+        "Formats", "Alignments", "Blockquote", "|", "NumberFormatList",
+        "BulletFormatList", "|", "CreateLink", "Image", "CreateTable", "|", "ClearFormat", "SourceCode"};
+       ViewBag.InsertImageSettings = new Syncfusion.EJ2.RichTextEditor.RichTextEditorImageSettings
+      {
+        SaveUrl = hostUrl + "api/RichTextEditor/SaveFile",
+        RemoveUrl = hostUrl + "api/RichTextEditor/DeleteFile",
+        Path = hostUrl + "RichTextEditor/"
+      };
+       ViewBag.ExportWord = new Syncfusion.EJ2.RichTextEditor.RichTextEditorExportWord
+      {
+        ServiceUrl = hostUrl + "api/RichTextEditor/ExportToDocx",
+        FileName = "RichTextEditor.docx",
+        Stylesheet = ".e-rte-content{ font-size: 1em; font-weight: 400; margin: 0; }"
+      };
+
+       ViewBag.ExportPdf = new Syncfusion.EJ2.RichTextEditor.RichTextEditorExportPdf
+      {
+        ServiceUrl = hostUrl + "api/RichTextEditor/ExportToPdf",
+        FileName = "RichTextEditor.pdf",
+        Stylesheet = ".e-rte-content{ font-size: 1em; font-weight: 400; margin: 0; }"
+      };
+        return View();
+    }
+}

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/export/razor
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/export/razor
@@ -1,0 +1,2 @@
+@Html.EJS().RichTextEditor("exportEditor").ToolbarSettings(e =>
+    e.Items((object)ViewBag.items)).ExportWord(ViewBag.ExportWord).ExportPdf(ViewBag.ExportPdf).Value((string)ViewBag.Value).EnableXhtml(true).InsertImageSettings(ViewBag.InsertImageSettings).Render()

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/export/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/export/tagHelper
@@ -1,0 +1,11 @@
+<ejs-richtexteditor id="exportRTE" value="@Value" enableXhtml="true">
+    <e-richtexteditor-toolbarsettings items="@ViewBag.items"></e-richtexteditor-toolbarsettings>
+    <e-richtexteditor-insertimagesettings saveUrl="@InsertImageSettings.SaveUrl" removeUrl="@InsertImageSettings.RemoveUrl"
+        path="@InsertImageSettings.Path"></e-richtexteditor-insertimagesettings>
+    <e-richtexteditor-exportword serviceUrl="@ExportWord.ServiceUrl"
+        fileName="@ExportWord.FileName" stylesheet="@ExportWord.Stylesheet">
+    </e-richtexteditor-exportword>
+    <e-richtexteditor-exportpdf serviceUrl="@ExportPdf.ServiceUrl"
+        fileName="@ExportPdf.FileName" stylesheet="@ExportPdf.Stylesheet">
+    </e-richtexteditor-exportpdf>
+  </ejs-richtexteditor>

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/import/controller.cs
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/import/controller.cs
@@ -1,0 +1,24 @@
+public class HomeController : Controller
+{
+
+    public ActionResult Index()
+    {
+        ViewBag.Value = "<h2 style=\"text-align: center;\">Invitation to Microsoft Webinar Meet-Up</h2><p> Dear Guest, </p><p> We're thrilled to extend a special invitation to you for an exclusive Microsoft webinar meet-up, where we'll explore the latest innovations and insights driving the future of technology. As a valued member of our community, we believe this event will offer invaluable knowledge and networking opportunities. </p><h2>Event Details:</h2><table class=\"e-rte-table\" style=\"width: 100%; height: 125px;\"> <tbody> <tr style=\"height: 20%;\"> <th class=\"\">Time:</th> <td>10:00 AM - 12:00 PM</td> </tr> <tr style=\"height: 20%;\"> <th>Duration:</th> <td>2 hours</td> </tr> <tr style=\"height: 20%;\"> <th>Platform:</th> <td>Microsoft Teams</td> </tr> </tbody></table><p><br></p><h2>Agenda:</h2><ul> <li>Introduction to Cutting-Edge Microsoft Technologies</li> <li>Deep Dive into AI in Business: Leveraging Microsoft Azure Solutions</li> <li>Live Q&amp;A Session with Industry Experts</li> <li>Networking Opportunities with Peers and Professionals</li> </ul><h2>Why Attend?</h2><ul> <li>Gain insights into the latest trends and advancements in technology.</li> <li>Interact with industry experts and expand your professional network.</li> <li>Get your questions answered in real-time during the live Q&amp;A session.</li> <li>Access exclusive resources and offers available only to webinar attendees.</li> </ul><p> Feel free to invite your colleagues and peers who might benefit from this enriching experience. Simply forward this email to them or share the event details. </p><p> We're looking forward to your participation and to exploring the exciting world of Microsoft technology together. Should you have any questions or require further information, please don't hesitate to contact us at <a href=\"mailto:webinar@company.com\">webinar@company.com</a>.</p><p> <br></p><p>Warm regards,</p><p>John Doe<br>Event Coordinator<br>ABC Company</p>";
+        ViewBag.items = new[] { "Undo", "Redo", "|", "ImportWord", "|",
+        "Bold", "Italic", "Underline", "StrikeThrough", "|",
+        "FontName", "FontSize", "FontColor", "BackgroundColor", "|",
+        "Formats", "Alignments", "Blockquote", "|", "NumberFormatList", "BulletFormatList",
+        "|", "CreateLink", "Image", "CreateTable", "|", "ClearFormat", "SourceCode"};
+        ViewBag.InsertImageSettings = new Syncfusion.EJ2.RichTextEditor.RichTextEditorImageSettings
+            {
+                SaveUrl = hostUrl + "api/RichTextEditor/SaveFile",
+                RemoveUrl = hostUrl + "api/RichTextEditor/DeleteFile",
+                Path = hostUrl + "RichTextEditor/"
+            };
+        ViewBag.ImportWord = new Syncfusion.EJ2.RichTextEditor.RichTextEditorImportWord
+            {
+                ServiceUrl = hostUrl + "api/RichTextEditor/ImportFromWord",
+            };
+        return View();
+    }
+}

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/import/razor
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/import/razor
@@ -1,0 +1,2 @@
+@Html.EJS().RichTextEditor("importEditor").ToolbarSettings(e =>
+e.Items((object)ViewBag.items)).ImportWord(ViewBag.ImportWord).Value((string)ViewBag.Value).EnableXhtml(true).InsertImageSettings(ViewBag.InsertImageSettings).Render()

--- a/ej2-asp-core-mvc/code-snippet/rich-text-editor/import/tagHelper
+++ b/ej2-asp-core-mvc/code-snippet/rich-text-editor/import/tagHelper
@@ -1,0 +1,8 @@
+<ejs-richtexteditor id="importRTE" value="@Value">
+    <e-richtexteditor-toolbarsettings items="@ViewBag.items"></e-richtexteditor-toolbarsettings>
+    <e-richtexteditor-insertimagesettings saveUrl="@InsertImageSettings.SaveUrl"
+        removeUrl="@InsertImageSettings.RemoveUrl"
+        path="@InsertImageSettings.Path"></e-richtexteditor-insertimagesettings>
+    <e-richtexteditor-importword serviceUrl="@ImportWord.ServiceUrl">
+    </e-richtexteditor-importword>
+  </ejs-richtexteditor>

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/import-and-export.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/import-and-export.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import/Export in ##Platform_Name## Rich Text Editor Component | Syncfusion
-description: Learn here all about Import/Export in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
+title: Import/Export in ##Platform_Name## Rich Text Editor Control | Syncfusion
+description: Learn here all about Import/Export in Syncfusion ##Platform_Name## Rich Text Editor control of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Import/Export
 publishingplatform: ##Platform_Name##
@@ -9,7 +9,7 @@ documentation: ug
 ---
 
 
-# Import/Export in ##Platform_Name## Rich Text Editor component
+# Import/Export in ##Platform_Name## Rich Text Editor control
 
 ## Import from Microsoft Word
 

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/import-and-export.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.MVC/import-and-export.md
@@ -1,0 +1,216 @@
+---
+layout: post
+title: Import/Export in ##Platform_Name## Rich Text Editor Component | Syncfusion
+description: Learn here all about Import/Export in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
+platform: ej2-asp-core-mvc
+control: Import/Export
+publishingplatform: ##Platform_Name##
+documentation: ug
+---
+
+
+# Import/Export in ##Platform_Name## Rich Text Editor component
+
+## Import from Microsoft Word
+
+The Rich Text Editor allows you to import content from Word documents, preserving the original formatting and structure, including headings, lists, tables, and text styles. This ensures that documents are accurately represented within the editor for seamless editing and enhancement
+
+To integrate an `ImportWord` option into the Rich Text Editor toolbar using the `ToolbarSettings` [Items](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorToolbarSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorToolbarSettings_Items) property.
+
+To enable the `ImportWord` functionality, the `ServiceUrl` property must be correctly configured within the `ImportWord`. This API endpoint facilitates the file upload process and manages the server-side conversion of the document.
+
+The following code block provides a detailed explanation of the API endpoint used for the import functionality:
+
+```csharp
+
+    public IActionResult ImportFromWord(IList<IFormFile> UploadFiles)
+        {
+            string HtmlString = string.Empty;
+            if (UploadFiles != null)
+            {
+                foreach (var file in UploadFiles)
+                {
+                    string filename = ContentDispositionHeaderValue.Parse(file.ContentDisposition).FileName.Trim('"');
+                    filename = _webHostEnvironment.WebRootPath + $@"\{filename}";
+                    using (FileStream fs = System.IO.File.Create(filename))
+                    {
+                        file.CopyTo(fs);
+                        fs.Flush();
+                    }
+                    using (var mStream = new MemoryStream())
+                    {
+                        new WordDocument(file.OpenReadStream(), FormatType.Rtf).Save(mStream, FormatType.Html);
+                        mStream.Position = 0;
+                        HtmlString = new StreamReader(mStream).ReadToEnd();
+                    };
+                    HtmlString = ExtractBodyContent(HtmlString);
+                    HtmlString = SanitizeHtml(HtmlString);
+                    System.IO.File.Delete(filename);
+                }
+                return Ok(HtmlString);
+            }
+            else
+            {
+                Response.Clear();
+                // Return an appropriate status code or message
+                return BadRequest("No files were uploaded.");
+            }
+        }
+
+        private string ExtractBodyContent(string html)
+        {
+            if (html.Contains("<html") && html.Contains("<body"))
+            {
+                return html.Remove(0, html.IndexOf("<body>") + 6).Replace("</body></html>", "");
+            }
+            return html;
+        }
+
+        private string SanitizeHtml(string html)
+        {
+            // Remove or replace non-ASCII or control characters
+            // For example, you can use regular expressions to replace them with spaces
+            // Regex pattern to match non-ASCII or control characters: [^\x20-\x7E]
+            return Regex.Replace(html, @"[^\x20-\x7E]", " ");
+        }
+
+
+```
+
+The `ImportWord` functionality is integrated within the `ActionBegin` and `ActionComplete` events. If the cancel property is set to true in the `ActionBegin` event argument, the execution of the `ImportWord` functionality can be prevented.
+
+The following example illustrates how to set up the `ImportWord` in the Rich Text Editor to facilitate content importation from Word documents:
+
+{% if page.publishingplatform == "aspnet-core" %}
+
+{% tabs %}
+{% highlight cshtml tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/import/tagHelper %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/import/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+{% tabs %}
+{% highlight razor tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/import/razor %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/import/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+{% endif %}
+
+## Export to PDF / Microsoft Word
+
+The Rich Text Editor's export functionality allows users to convert their edited content into PDF or Word documents with a single click, preserving all text styles, images, tables, and other formatting elements.
+
+You can add `ExportWord` and `ExportPdf` tools to the Rich Text Editor toolbar using the `ToolbarSettings` [Items](https://help.syncfusion.com/cr/aspnetmvc-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorToolbarSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorToolbarSettings_Items) property.
+
+To enable the `ExportWord` and `ExportPdf` functionality, the `ServiceUrl` property must be correctly configured within the `ExportWordModel` and `ExportPdfModel`. These API endpoints handle the export process and manage the server-side generation of Word and PDF files, respectively.
+
+The following code block provides a detailed explanation of the API endpoint used for the content export functionality:
+
+```csharp
+
+    public class ExportParam
+        {
+            public string html { get; set; }
+        }
+
+        [AcceptVerbs("Post")]
+        [EnableCors("AllowAllOrigins")]
+        [Route("ExportToPdf")]
+        public ActionResult ExportToPdf([FromBody] ExportParam args)
+        {
+            string htmlString = args.html;
+            if (htmlString == null && htmlString == "")
+            {
+                return null;
+            }
+            using (WordDocument wordDocument = new WordDocument())
+            {
+                //This method adds a section and a paragraph in the document
+                wordDocument.EnsureMinimal();
+                wordDocument.HTMLImportSettings.ImageNodeVisited += OpenImage;
+                //Append the HTML string to the paragraph.
+                wordDocument.LastParagraph.AppendHTML(htmlString);
+                DocIORenderer render = new DocIORenderer();
+                //Converts Word document into PDF document
+                PdfDocument pdfDocument = render.ConvertToPDF(wordDocument);
+                wordDocument.HTMLImportSettings.ImageNodeVisited -= OpenImage;
+                MemoryStream stream = new MemoryStream();
+                pdfDocument.Save(stream);
+                return File(stream.ToArray(), System.Net.Mime.MediaTypeNames.Application.Pdf, "Sample.pdf");
+            }
+        }
+
+        [AcceptVerbs("Post")]
+        [EnableCors("AllowAllOrigins")]
+        [Route("ExportToDocx")]
+        public FileStreamResult ExportToDocx([FromBody] ExportParam args)
+        {
+            string htmlString = args.html;
+            if (htmlString == null && htmlString == "")
+            {
+                return null;
+            }
+            using (WordDocument document = new WordDocument())
+            {
+                document.EnsureMinimal();
+                //Hooks the ImageNodeVisited event to open the image from a specific location
+                document.HTMLImportSettings.ImageNodeVisited += OpenImage;
+                //Validates the Html string
+                bool isValidHtml = document.LastSection.Body.IsValidXHTML(htmlString, XHTMLValidationType.None);
+                //When the Html string passes validation, it is inserted to the document
+                if (isValidHtml)
+                {
+                    //Appends the Html string to first paragraph in the document
+                    document.Sections[0].Body.Paragraphs[0].AppendHTML(htmlString);
+                }
+                //Unhooks the ImageNodeVisited event after loading HTML
+                document.HTMLImportSettings.ImageNodeVisited -= OpenImage;
+                //Creates file stream.
+                MemoryStream stream = new MemoryStream();
+                document.Save(stream, FormatType.Docx);
+                stream.Position = 0;
+                //Download Word document in the browser
+                return File(stream, "application/msword", "Result.docx");
+            }
+        }
+
+```
+
+The `FileName` and `Stylesheet` properties within the `ExportWord` and `ExportPdf` allow for the customization of file names and stylesheets for the exported documents, respectively.
+
+The `ExportWord` and `ExportPdf` functionality is integrated within the `ActionBegin` and `ActionComplete` events. If the cancel property is set to true in the `ActionBegin` event argument, the execution of the `ExportWord` and `ExportPdf` functionality can be prevented.
+
+The `ActionBegin` event argument includes an `ExportValue` property, which contains the content to be exported. This content can be modified by configuring the `ActionBegin` event.
+
+The following example demonstrates how to configure the `ExportWord` and `ExportPdf` tools in the Rich Text Editor, facilitating the export of content into Word or PDF documents:
+
+{% if page.publishingplatform == "aspnet-core" %}
+
+{% tabs %}
+{% highlight cshtml tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/export/tagHelper %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/export/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+{% tabs %}
+{% highlight razor tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/export/razor %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/export/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+{% endif %}

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/import-and-export.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/import-and-export.md
@@ -1,0 +1,216 @@
+---
+layout: post
+title: Import/Export in ##Platform_Name## Rich Text Editor Component | Syncfusion
+description: Learn here all about Import/Export in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
+platform: ej2-asp-core-mvc
+control: Import/Export
+publishingplatform: ##Platform_Name##
+documentation: ug
+---
+
+
+# Import/Export in ##Platform_Name## Rich Text Editor component
+
+## Import from Microsoft Word
+
+The Rich Text Editor allows you to import content from Word documents, preserving the original formatting and structure, including headings, lists, tables, and text styles. This ensures that documents are accurately represented within the editor for seamless editing and enhancement
+
+To integrate an `ImportWord` option into the Rich Text Editor toolbar using the `ToolbarSettings` [Items](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorToolbarSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorToolbarSettings_Items) property.
+
+To enable the `ImportWord` functionality, the `ServiceUrl` property must be correctly configured within the `ImportWord`. This API endpoint facilitates the file upload process and manages the server-side conversion of the document.
+
+The following code block provides a detailed explanation of the API endpoint used for the import functionality:
+
+```csharp
+
+    public IActionResult ImportFromWord(IList<IFormFile> UploadFiles)
+        {
+            string HtmlString = string.Empty;
+            if (UploadFiles != null)
+            {
+                foreach (var file in UploadFiles)
+                {
+                    string filename = ContentDispositionHeaderValue.Parse(file.ContentDisposition).FileName.Trim('"');
+                    filename = _webHostEnvironment.WebRootPath + $@"\{filename}";
+                    using (FileStream fs = System.IO.File.Create(filename))
+                    {
+                        file.CopyTo(fs);
+                        fs.Flush();
+                    }
+                    using (var mStream = new MemoryStream())
+                    {
+                        new WordDocument(file.OpenReadStream(), FormatType.Rtf).Save(mStream, FormatType.Html);
+                        mStream.Position = 0;
+                        HtmlString = new StreamReader(mStream).ReadToEnd();
+                    };
+                    HtmlString = ExtractBodyContent(HtmlString);
+                    HtmlString = SanitizeHtml(HtmlString);
+                    System.IO.File.Delete(filename);
+                }
+                return Ok(HtmlString);
+            }
+            else
+            {
+                Response.Clear();
+                // Return an appropriate status code or message
+                return BadRequest("No files were uploaded.");
+            }
+        }
+
+        private string ExtractBodyContent(string html)
+        {
+            if (html.Contains("<html") && html.Contains("<body"))
+            {
+                return html.Remove(0, html.IndexOf("<body>") + 6).Replace("</body></html>", "");
+            }
+            return html;
+        }
+
+        private string SanitizeHtml(string html)
+        {
+            // Remove or replace non-ASCII or control characters
+            // For example, you can use regular expressions to replace them with spaces
+            // Regex pattern to match non-ASCII or control characters: [^\x20-\x7E]
+            return Regex.Replace(html, @"[^\x20-\x7E]", " ");
+        }
+
+
+```
+
+The `ImportWord` functionality is integrated within the `ActionBegin` and `ActionComplete` events. If the cancel property is set to true in the `ActionBegin` event argument, the execution of the `ImportWord` functionality can be prevented.
+
+The following example illustrates how to set up the `ImportWord` in the Rich Text Editor to facilitate content importation from Word documents:
+
+{% if page.publishingplatform == "aspnet-core" %}
+
+{% tabs %}
+{% highlight cshtml tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/import/tagHelper %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/import/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+{% tabs %}
+{% highlight razor tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/import/razor %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/import/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+{% endif %}
+
+## Export to PDF / Microsoft Word
+
+The Rich Text Editor's export functionality allows users to convert their edited content into PDF or Word documents with a single click, preserving all text styles, images, tables, and other formatting elements.
+
+You can add `ExportWord` and `ExportPdf` tools to the Rich Text Editor toolbar using the `ToolbarSettings` [Items](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.RichTextEditor.RichTextEditorToolbarSettings.html#Syncfusion_EJ2_RichTextEditor_RichTextEditorToolbarSettings_Items) property.
+
+To enable the `ExportWord` and `ExportPdf` functionality, the `ServiceUrl` property must be correctly configured within the `ExportWordModel` and `ExportPdfModel`. These API endpoints handle the export process and manage the server-side generation of Word and PDF files, respectively.
+
+The following code block provides a detailed explanation of the API endpoint used for the content export functionality:
+
+```csharp
+
+    public class ExportParam
+        {
+            public string html { get; set; }
+        }
+
+        [AcceptVerbs("Post")]
+        [EnableCors("AllowAllOrigins")]
+        [Route("ExportToPdf")]
+        public ActionResult ExportToPdf([FromBody] ExportParam args)
+        {
+            string htmlString = args.html;
+            if (htmlString == null && htmlString == "")
+            {
+                return null;
+            }
+            using (WordDocument wordDocument = new WordDocument())
+            {
+                //This method adds a section and a paragraph in the document
+                wordDocument.EnsureMinimal();
+                wordDocument.HTMLImportSettings.ImageNodeVisited += OpenImage;
+                //Append the HTML string to the paragraph.
+                wordDocument.LastParagraph.AppendHTML(htmlString);
+                DocIORenderer render = new DocIORenderer();
+                //Converts Word document into PDF document
+                PdfDocument pdfDocument = render.ConvertToPDF(wordDocument);
+                wordDocument.HTMLImportSettings.ImageNodeVisited -= OpenImage;
+                MemoryStream stream = new MemoryStream();
+                pdfDocument.Save(stream);
+                return File(stream.ToArray(), System.Net.Mime.MediaTypeNames.Application.Pdf, "Sample.pdf");
+            }
+        }
+
+        [AcceptVerbs("Post")]
+        [EnableCors("AllowAllOrigins")]
+        [Route("ExportToDocx")]
+        public FileStreamResult ExportToDocx([FromBody] ExportParam args)
+        {
+            string htmlString = args.html;
+            if (htmlString == null && htmlString == "")
+            {
+                return null;
+            }
+            using (WordDocument document = new WordDocument())
+            {
+                document.EnsureMinimal();
+                //Hooks the ImageNodeVisited event to open the image from a specific location
+                document.HTMLImportSettings.ImageNodeVisited += OpenImage;
+                //Validates the Html string
+                bool isValidHtml = document.LastSection.Body.IsValidXHTML(htmlString, XHTMLValidationType.None);
+                //When the Html string passes validation, it is inserted to the document
+                if (isValidHtml)
+                {
+                    //Appends the Html string to first paragraph in the document
+                    document.Sections[0].Body.Paragraphs[0].AppendHTML(htmlString);
+                }
+                //Unhooks the ImageNodeVisited event after loading HTML
+                document.HTMLImportSettings.ImageNodeVisited -= OpenImage;
+                //Creates file stream.
+                MemoryStream stream = new MemoryStream();
+                document.Save(stream, FormatType.Docx);
+                stream.Position = 0;
+                //Download Word document in the browser
+                return File(stream, "application/msword", "Result.docx");
+            }
+        }
+
+```
+
+The `FileName` and `Stylesheet` properties within the `ExportWord` and `ExportPdf` allow for the customization of file names and stylesheets for the exported documents, respectively.
+
+The `ExportWord` and `ExportPdf` functionality is integrated within the `ActionBegin` and `ActionComplete` events. If the cancel property is set to true in the `ActionBegin` event argument, the execution of the `ExportWord` and `ExportPdf` functionality can be prevented.
+
+The `ActionBegin` event argument includes an `ExportValue` property, which contains the content to be exported. This content can be modified by configuring the `ActionBegin` event.
+
+The following example demonstrates how to configure the `ExportWord` and `ExportPdf` tools in the Rich Text Editor, facilitating the export of content into Word or PDF documents:
+
+{% if page.publishingplatform == "aspnet-core" %}
+
+{% tabs %}
+{% highlight cshtml tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/export/tagHelper %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/export/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+
+{% elsif page.publishingplatform == "aspnet-mvc" %}
+
+{% tabs %}
+{% highlight razor tabtitle="CSHTML" %}
+{% include code-snippet/rich-text-editor/export/razor %}
+{% endhighlight %}
+{% highlight c# tabtitle="Controller.cs" %}
+{% include code-snippet/rich-text-editor/export/controller.cs %}
+{% endhighlight %}
+{% endtabs %}
+{% endif %}

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/import-and-export.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/import-and-export.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import/Export in ##Platform_Name## Rich Text Editor Component | Syncfusion
-description: Learn here all about Import/Export in Syncfusion ##Platform_Name## Rich Text Editor component of Syncfusion Essential JS 2 and more.
+title: Import/Export in ##Platform_Name## Rich Text Editor Control | Syncfusion
+description: Learn here all about Import/Export in Syncfusion ##Platform_Name## Rich Text Editor control of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Import/Export
 publishingplatform: ##Platform_Name##
@@ -9,7 +9,7 @@ documentation: ug
 ---
 
 
-# Import/Export in ##Platform_Name## Rich Text Editor component
+# Import/Export in ##Platform_Name## Rich Text Editor control
 
 ## Import from Microsoft Word
 

--- a/ej2-asp-core-toc.html
+++ b/ej2-asp-core-toc.html
@@ -2253,6 +2253,7 @@
 		<li><a href="/ej2-asp-core/rich-text-editor/toolbar">Toolbar</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/styling">Styling</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/image">Image</a></li>
+		<li><a href="/ej2-asp-core/rich-text-editor/import-and-export">Import/Export</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/audio">Audio</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/video">Video</a></li>
 		<li><a href="/ej2-asp-core/rich-text-editor/link">Link</a></li>

--- a/ej2-asp-mvc-toc.html
+++ b/ej2-asp-mvc-toc.html
@@ -2212,6 +2212,7 @@
 		<li><a href="/ej2-asp-mvc/rich-text-editor/toolbar">Toolbar</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/styling">Styling</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/image">Image</a></li>
+		<li><a href="/ej2-asp-mvc/rich-text-editor/import-and-export">Import/Export</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/audio">Audio</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/video">Video</a></li>
 		<li><a href="/ej2-asp-mvc/rich-text-editor/link">Link</a></li>


### PR DESCRIPTION
### Bug description
To add documentation for Import/export feature in all the platform except angular

### Root Cause / Analysis
Need to add an Import/export documentation.

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?
No

### Solution Description
Created an  Import/export documentation.

### Areas affected and ensured

No

### E2E report details against this fix

No

### Did you included unit test cases.?

NA

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner