### PR TITLE
1234: highlight Lexer issue fix and close highlight

### DIFF
--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/print.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/print.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Print in ##Platform_Name## Pdfviewer Component
+title: Print in EJ2 ASP.NET MVC PDF Viewer | Syncfusion
 description: Learn here all about Print in Syncfusion ##Platform_Name## Pdfviewer component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Print
@@ -8,7 +8,7 @@ publishingplatform: ##Platform_Name##
 documentation: ug
 ---
 
-# Print
+# Print in ASP.NET MVC PDFViewer Control
 
 The PDF Viewer supports printing the loaded PDF file. You can enable/disable the print using the following code snippet.
 
@@ -85,6 +85,7 @@ By default, the printScaleFactor is set to 1.
 </script>
 ```
 {% endhighlight %}
+{% endtabs %}
 ## See also
 
 * [Toolbar items](./toolbar)

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/print.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/print.md
@@ -84,6 +84,7 @@ By default, the printScaleFactor is set to 1.
     }
 </script>
 ```
+{% endhighlight %}
 ## See also
 
 * [Toolbar items](./toolbar)

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/text-search.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/text-search.md
@@ -13,21 +13,17 @@ documentation: ug
 The Text Search option in PDF Viewer is used to find and highlight the text content from the document. You can enable/disable the text search using the following code snippet.
 
 {% tabs %}
-{% highlight html tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
-```html
     <div style="width:100%;height:600px">
         @Html.EJS().PdfViewer("pdfviewer").EnableTextSearch(true).DocumentPath("https://cdn.syncfusion.com/content/pdf/hive-succinctly.pdf").Render()
     </div>
-```
 {% endhighlight %}
-{% highlight html tabtitle="Server-Backed" %}
+{% highlight cshtml tabtitle="Server-Backed" %}
 
-```html
     <div style="width:100%;height:600px">
         @Html.EJS().PdfViewer("pdfviewer").ServiceUrl(VirtualPathUtility.ToAbsolute("~/api/PdfViewer/")).EnableTextSearch(true).DocumentPath("https://cdn.syncfusion.com/content/pdf/hive-succinctly.pdf").Render()
     </div>
-```
 {% endhighlight %}
 {% endtabs %}
 
@@ -65,7 +61,7 @@ Searches for the specified text or an array of strings within the document and r
 Searches for the specified text within the document and returns the bounding rectangles of the matched text. The search can be case-sensitive based on the provided parameter. It returns the bounding rectangles for all pages in the document where the text was found. The below code snippet shows how to get the bounds of the given text:
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -80,7 +76,7 @@ Searches for the specified text within the document and returns the bounding rec
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -101,7 +97,7 @@ Searches for the specified text within the document and returns the bounding rec
 Searches for the specified text within the document and returns the bounding rectangles of the matched text. The search can be case-sensitive based on the provided parameter. It returns the bounding rectangles for that page in the document where the text was found. The below code snippet shows how to get the bounds of the given text from the desired page:
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -116,7 +112,7 @@ Searches for the specified text within the document and returns the bounding rec
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -137,7 +133,7 @@ Searches for the specified text within the document and returns the bounding rec
 Searches for an array of strings within the document and returns the bounding rectangles for each occurrence. The search can be case-sensitive based on the provided parameters. It returns the bounding rectangles for all pages in the document where the strings were found.
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -152,7 +148,7 @@ Searches for an array of strings within the document and returns the bounding re
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -173,7 +169,7 @@ Searches for an array of strings within the document and returns the bounding re
 Searches for an array of strings within the document and returns the bounding rectangles for each occurrence. The search can be case-sensitive based on the provided parameters. It returns the bounding rectangles for these search strings on that particular page where the strings were found.
 
 {% tabs %}
-{% highlight MVC tabtitle="standalone" %}
+{% highlight cshtml tabtitle="standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">
@@ -188,7 +184,7 @@ Searches for an array of strings within the document and returns the bounding re
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 <div style="width:100%;height:600px">

--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/text-search.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.NETCORE/text-search.md
@@ -72,7 +72,7 @@ Searches for the specified text or an array of strings within the document and r
 Searches for the specified text within the document and returns the bounding rectangles of the matched text. The search can be case-sensitive based on the provided parameter. It returns the bounding rectangles for all pages in the document where the text was found. The below code snippet shows how to get the bounds of the given text:
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -92,7 +92,7 @@ Searches for the specified text within the document and returns the bounding rec
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -118,7 +118,7 @@ Searches for the specified text within the document and returns the bounding rec
 Searches for the specified text within the document and returns the bounding rectangles of the matched text. The search can be case-sensitive based on the provided parameter. It returns the bounding rectangles for that page in the document where the text was found. The below code snippet shows how to get the bounds of the given text from the desired page:
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -138,7 +138,7 @@ Searches for the specified text within the document and returns the bounding rec
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -164,7 +164,7 @@ Searches for the specified text within the document and returns the bounding rec
 Searches for an array of strings within the document and returns the bounding rectangles for each occurrence. The search can be case-sensitive based on the provided parameters. It returns the bounding rectangles for all pages in the document where the strings were found.
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -184,7 +184,7 @@ Searches for an array of strings within the document and returns the bounding re
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -210,7 +210,7 @@ Searches for an array of strings within the document and returns the bounding re
 Searches for an array of strings within the document and returns the bounding rectangles for each occurrence. The search can be case-sensitive based on the provided parameters. It returns the bounding rectangles for these search strings on that particular page where the strings were found.
 
 {% tabs %}
-{% highlight MVC tabtitle="Standalone" %}
+{% highlight cshtml tabtitle="Standalone" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 
@@ -230,7 +230,7 @@ Searches for an array of strings within the document and returns the bounding re
 </script>
 
 {% endhighlight %}
-{% highlight MVC tabtitle="Server-backed" %}
+{% highlight cshtml tabtitle="Server-backed" %}
 
 <button type="button" onclick="findTextBounds()">FindTextBounds</button>
 


### PR DESCRIPTION
Description:
Highlight tag closed properly in print md file and Lexer issue addressed for text search md files in both core and MVC.