### PR TITLE
SEO-200103-EJ2-ASP.NET-MVC-pdfviewer-Title-too-long

### DIFF
--- a/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/annotation/text-markup-annotation.md
+++ b/ej2-asp-core-mvc/pdfviewer/EJ2_ASP.MVC/annotation/text-markup-annotation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Text Markup Annotation Support in ##Platform_Name## PDF Viewer Component | Syncfusion
+title: Text Markup Annotations in ##Platform_Name## PDF Viewer | Syncfusion
 description: Learn here all about Text Markup Annotation in Syncfusion ##Platform_Name## PDF Viewer component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Text Markup Annotation


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Site Audit work- Title too long|
|Content Task Link/Mail Screenshot |![image](https://github.com/user-attachments/assets/c0de89e6-28b9-4552-9871-ce5299d1e7e7)|
|Hotfix |https://github.com/syncfusion-content/ej2-asp-core-mvc-docs/pull/4146 |
|Ticket/Task link |https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/200103 |
|Work link |https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7Bc4d37df0-3f11-4b4c-a5c2-eabff4e4c288%7D&action=edit&activeCell=%27Title%20Too%20Long%27!A5&wdinitialsession=8f0d24f1-fe24-764a-c28b-f181fb1a9b15&wdrldsc=2&wdrldc=1&wdrldr=AccessTokenExpiredWarning%2CRefreshingExpiredAccessT|

Changes Made | Reason for change |
|-- | -- |
| Worked on Title too long | In SEO the title should range between 20 to 70 character counts|