### PR TITLE
965432: Need to add section in Defined name section with public method details and their scope

### DIFF
--- a/ej2-asp-core-mvc/spreadsheet/formulas.md
+++ b/ej2-asp-core-mvc/spreadsheet/formulas.md
@@ -126,6 +126,28 @@ You can define a meaningful name for a cell range and use it in the formula for 
 * You can remove an added named range dynamically using the `removeDefinedName` method.
 * Select the range of cells, and then enter the name for the selected range in the name box.
 
+### Properties of DefinedName
+
+A defined name in the Spreadsheet supports the following key properties:
+
+- **[`name`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Spreadsheet.DefinedName.html#Syncfusion_EJ2_Spreadsheet_DefinedName_Name)**: A unique identifier to represent a specific range or formula.
+
+- **[`refersTo`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Spreadsheet.DefinedName.html#Syncfusion_EJ2_Spreadsheet_DefinedName_RefersTo)**: The cell reference or formula that the name refers to.
+  - You can specify it **with or without** the `=` prefix.
+  - **Example**: `'A1:B5'` or `'=A1:B5'` are both valid.
+
+- **[`scope`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.Spreadsheet.DefinedName.html#Syncfusion_EJ2_Spreadsheet_DefinedName_Scope)** (optional): Indicates whether the name is accessible across the **workbook** or only within a **specific sheet**.
+  - If `scope` is not specified, it defaults to `"Workbook"`.
+  - If a sheet name is provided as `scope`, the name will be available only within that sheet.
+
+```csharp
+spreadsheet.addDefinedName({
+  name: 'rangeName',
+  refersTo: '=C2:C10',
+  scope: 'Sheet1' // local to Sheet1
+});
+```
+
 The following code example shows the usage of named ranges support.
 
 {% if page.publishingplatform == "aspnet-core" %}


### PR DESCRIPTION
Description:

The addDefinedName method in the Spreadsheet component allows developers to create custom named ranges or constants that can be reused in formulas. However, the current documentation lacks clarity on the usage of the referTo and scope properties.

To improve understanding, we must document:

- How to use the addDefinedName method.
- How the referTo value can be passed with or without the = prefix.
- The purpose and behavior of the scope property, including its default behavior when omitted.
- Usage examples for both globally scoped and sheet-scoped defined names.
- This addition will help users apply named ranges more effectively and understand their accessibility across sheets.

Task link - https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/965432
Content link - https://github.com/syncfusion-content/ej2-asp-core-mvc-docs