### PR TITLE
SEO-204554-Asp.net-Mvc-Description-long-Hotfix

### DIFF
--- a/ej2-asp-core-mvc/progress-button/how-to/change-the-text-content-and-styles-of-the-progressbutton-during-progress.md
+++ b/ej2-asp-core-mvc/progress-button/how-to/change-the-text-content-and-styles-of-the-progressbutton-during-progress.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Change The Text Content And Styles Of The Progressbutton During Progress in ##Platform_Name## Progress Button Component
-description: Learn here all about Change The Text Content And Styles Of The Progressbutton During Progress in Syncfusion ##Platform_Name## Progress Button component of syncfusion and more.
+description: Learn here all about Changing The Text Content And Styles Of The Progress button in Syncfusion ##Platform_Name## and more.
 platform: ej2-asp-core-mvc
 control: Change The Text Content And Styles Of The Progressbutton During Progress
 publishingplatform: ##Platform_Name##


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Meta Description too long|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204554|
|Share point| [share point](https://syncfusion-my.sharepoint.com/:x:/p/mallika_kannan/EQqtb1gQd9pEiVkIQmHydnABkMETPelwV42V_5voCRbxgQ?wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1751515828401&web=1)|



Changes Made | Reason for change |
|-- | -- |
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha