### PR TITLE
SEO-204554-H1-Title-Same-Hotfix

### DIFF
--- a/ej2-asp-core-mvc/chart/EJ2_ASP.NETCORE/chart-types/line.md
+++ b/ej2-asp-core-mvc/chart/EJ2_ASP.NETCORE/chart-types/line.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Line Chart in ##Platform_Name## Charts
+title: Line Chart in ##Platform_Name## Charts | Syncfusion
 description: Learn here all about Line Chart in Syncfusion ##Platform_Name## Charts component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Line Chart

--- a/ej2-asp-core-mvc/chart/EJ2_ASP.NETCORE/trend-lines.md
+++ b/ej2-asp-core-mvc/chart/EJ2_ASP.NETCORE/trend-lines.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Trend Lines in ##Platform_Name## Chart Component
+title: Trend Lines in ##Platform_Name## Chart Component | Syncfusion
 description: Learn here all about Trend Lines in Syncfusion ##Platform_Name## Chart component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Trend Lines

--- a/ej2-asp-core-mvc/gantt/resource-view.md
+++ b/ej2-asp-core-mvc/gantt/resource-view.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Resource View in ##Platform_Name## Gantt Component
+title: Resource View in ##Platform_Name## Gantt Component | Syncfusion
 description: Learn here all about Resource View in Syncfusion ##Platform_Name## Gantt component of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Resource View

--- a/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/paste-cleanup.md
+++ b/ej2-asp-core-mvc/rich-text-editor/EJ2_ASP.NETCORE/paste-cleanup.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Paste Cleanup in ##Platform_Name## Rich Text Editor Control
+title: Paste Cleanup in ##Platform_Name## Rich Text Editor Control | Syncfusion
 description: Learn here all about Paste Cleanup in Syncfusion ##Platform_Name## Rich Text Editor control of Syncfusion Essential JS 2 and more.
 platform: ej2-asp-core-mvc
 control: Paste Cleanup


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 title same|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204554|
|Share point| [share point](https://syncfusion-my.sharepoint.com/:x:/p/mallika_kannan/EQqtb1gQd9pEiVkIQmHydnABkMETPelwV42V_5voCRbxgQ?wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1751515828401&web=1)|



Changes Made | Reason for change |
|-- | -- |
|Change the meta title I In SEO, the H1 tag and the meta title should be different, so I changed the meta title.|


Regards, 
Asha