### PR TITLE
SEO-204554-Asp.net.core-Multiple-H1-tag-Hotfix

### DIFF
--- a/ej2-asp-core-mvc/pivot-table/EJ2_ASP.NETCORE/state-persistence.md
+++ b/ej2-asp-core-mvc/pivot-table/EJ2_ASP.NETCORE/state-persistence.md
@@ -38,7 +38,7 @@ State persistence allows user to maintain the current state of the component alo
 
 
 
-# Save and Load Pivot Layout
+## Save and Load Pivot Layout
 
 You can save the current layout of the pivot table by using `getPersistData` in string format. The saved layout can be loaded to pivot table any time by passing the saved data as a parameter to `loadPersistData` method in the [`ejs-pivotview`](https://help.syncfusion.com/cr/aspnetcore-js2/Syncfusion.EJ2.PivotView.PivotView.html).
 

--- a/ej2-asp-core-mvc/stock-chart/EJ2_ASP.NETCORE/range-selector.md
+++ b/ej2-asp-core-mvc/stock-chart/EJ2_ASP.NETCORE/range-selector.md
@@ -13,7 +13,7 @@ documentation: ug
 
 The period selector allows to select a range with specified periods. By default the period selector is enabled in stock chart.
 
-# Selecting Range
+## Selecting Range
 
 The left and right thumb of RangeNavigator are used to indicate the selected range in the large collection of data. Following are the ways you can select a range.
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Multiple-H1-tag|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204554|
|Share point| [share point](https://syncfusion-my.sharepoint.com/:x:/p/mallika_kannan/EQqtb1gQd9pEiVkIQmHydnABkMETPelwV42V_5voCRbxgQ?wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1751515828401&web=1)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag I One page should have only one H1 tag as per SEO rules, so I changed it.|


Regards, 
Asha