### PR TITLE
Add canonical URL to getting started documentation

### DIFF
--- a/ej2-asp-core-mvc/diagram/EJ2_ASP.NETCORE/getting-started.md
+++ b/ej2-asp-core-mvc/diagram/EJ2_ASP.NETCORE/getting-started.md
@@ -6,6 +6,7 @@ platform: ej2-asp-core-mvc
 control: Getting Started
 publishingplatform: ##Platform_Name##
 documentation: ug
+canonical_url: "https://www.syncfusion.com/aspnet-core-ui-controls/diagram"
 ---
 
 # Getting Started with ASP.NET Core Diagram Control


### PR DESCRIPTION
Added canonical URL for ASP.NET Core Diagram Control documentation.